### PR TITLE
fix: remove hardcoded StreamHandler from token_poller to preserve log formatting

### DIFF
--- a/src/agentarts/sdk/service/identity/polling/token_poller.py
+++ b/src/agentarts/sdk/service/identity/polling/token_poller.py
@@ -65,10 +65,7 @@ class DefaultApiTokenPoller(TokenPoller):
         """
         self.auth_url = auth_url
         self.polling_func = func
-        self.logger = logging.getLogger("agent_identity.default_token_poller")
-        self.logger.setLevel("INFO")
-        if not self.logger.handlers:
-            self.logger.addHandler(logging.StreamHandler())
+        self.logger = logging.getLogger("agentarts.token_poller")
 
     async def poll_for_token(self) -> str:
         """Poll for a token until it becomes available, fails, or times out.


### PR DESCRIPTION
## Description
Removed the hardcoded \StreamHandler\ and \setLevel\ in \DefaultApiTokenPoller\'s logger initialization.

**Reasoning:**
The \	oken_poller.py\ was instantiating a logger with a custom name (\gent_identity.default_token_poller\) and directly appending an unformatted \StreamHandler\ to it. This bypassed standard formatting configured at the application root, causing log entries to appear bare without timestamps, log levels, or modules (e.g. \Polling for token for authorization url...\ instead of \2026-06-17 08:50:30,588 - ... - INFO - Polling...\).

This change ensures the logger inherits standard configurations correctly from the parent \gentarts\ logger space.