### PR TITLE
feat(identity): expose credential provider query methods in IdentityClient

### DIFF
--- a/src/agentarts/sdk/service/identity/identity_client.py
+++ b/src/agentarts/sdk/service/identity/identity_client.py
@@ -49,6 +49,8 @@ from huaweicloudsdkagentidentity.v1 import (
     GetResourceStsTokenResponse,
     GetStsCredentialProviderRequest,
     GetStsCredentialProviderResponse,
+    GetWorkloadIdentityRequest,
+    GetWorkloadIdentityResponse,
     GithubOauth2ProviderConfigInput,
     GoogleOauth2ProviderConfigInput,
     ListApiKeyCredentialProvidersRequest,
@@ -57,6 +59,8 @@ from huaweicloudsdkagentidentity.v1 import (
     ListOauth2CredentialProvidersResponse,
     ListStsCredentialProvidersRequest,
     ListStsCredentialProvidersResponse,
+    ListWorkloadIdentitiesRequest,
+    ListWorkloadIdentitiesResponse,
     MicrosoftOauth2ProviderConfigInput,
     Oauth2CredentialProvider,
     Oauth2CredentialProviderSummary,
@@ -70,6 +74,7 @@ from huaweicloudsdkagentidentity.v1 import (
     UpdateWorkloadIdentityResponse,
     UserIdentifier,
     WorkloadIdentity,
+    WorkloadIdentitySummary,
 )
 from huaweicloudsdkcore.exceptions.exceptions import (
     SdkException,
@@ -228,6 +233,43 @@ class IdentityClient:
             )
         )
         return response.workload_identity
+
+    def get_workload_identity(self, name: str) -> WorkloadIdentity:
+        """Gets a specified workload identity.
+
+        Args:
+            name: The name of the workload identity.
+
+        Returns:
+            The WorkloadIdentity object.
+        """
+        self.logger.info(f"Getting workload identity: {name}")
+
+        response: GetWorkloadIdentityResponse = self.client.get_workload_identity(
+            request=GetWorkloadIdentityRequest(workload_identity_name=name)
+        )
+        return response.workload_identity
+
+    def list_workload_identities(
+        self,
+        limit: int | None = None,
+        marker: str | None = None,
+    ) -> list[WorkloadIdentitySummary]:
+        """Lists all workload identities.
+
+        Args:
+            limit: Optional limit for pagination.
+            marker: Optional marker for pagination.
+
+        Returns:
+            A list of WorkloadIdentitySummary objects.
+        """
+        self.logger.info("Listing workload identities...")
+
+        response: ListWorkloadIdentitiesResponse = self.client.list_workload_identities(
+            request=ListWorkloadIdentitiesRequest(limit=limit, marker=marker)
+        )
+        return response.workload_identities or []
 
     def create_api_key_credential_provider(
         self,

--- a/src/agentarts/sdk/service/identity/identity_client.py
+++ b/src/agentarts/sdk/service/identity/identity_client.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from huaweicloudsdkagentidentity.v1 import (
     AgentIdentityClient,
     ApiKeyCredentialProvider,
+    ApiKeyCredentialProviderSummary,
     AuthorizerType,
     CompleteResourceTokenAuthRequest,
     CompleteResourceTokenAuthRequestBody,
@@ -33,6 +34,10 @@ from huaweicloudsdkagentidentity.v1 import (
     CreateWorkloadIdentityRequest,
     CreateWorkloadIdentityResponse,
     CustomOauth2ProviderConfigInput,
+    GetApiKeyCredentialProviderRequest,
+    GetApiKeyCredentialProviderResponse,
+    GetOauth2CredentialProviderRequest,
+    GetOauth2CredentialProviderResponse,
     GetResourceApiKeyRequest,
     GetResourceApiKeyRequestBody,
     GetResourceApiKeyResponse,
@@ -42,12 +47,22 @@ from huaweicloudsdkagentidentity.v1 import (
     GetResourceStsTokenRequest,
     GetResourceStsTokenRequestBody,
     GetResourceStsTokenResponse,
+    GetStsCredentialProviderRequest,
+    GetStsCredentialProviderResponse,
     GithubOauth2ProviderConfigInput,
     GoogleOauth2ProviderConfigInput,
+    ListApiKeyCredentialProvidersRequest,
+    ListApiKeyCredentialProvidersResponse,
+    ListOauth2CredentialProvidersRequest,
+    ListOauth2CredentialProvidersResponse,
+    ListStsCredentialProvidersRequest,
+    ListStsCredentialProvidersResponse,
     MicrosoftOauth2ProviderConfigInput,
     Oauth2CredentialProvider,
+    Oauth2CredentialProviderSummary,
     Oauth2ProviderConfigInput,
     StsCredentialProvider,
+    StsCredentialProviderSummary,
     StsTag,
     Tag,
     UpdateWorkloadIdentityReqBody,
@@ -113,6 +128,7 @@ class IdentityClient:
             self.client = client
         else:
             from agentarts.sdk.utils.metadata import create_credential
+
             credentials = create_credential()
             self.client = (
                 AgentIdentityClient.new_builder()
@@ -122,14 +138,10 @@ class IdentityClient:
                 .build()
             )
 
-        self.logger.info(
-            f"Initialized Huawei Cloud Agent Identity client for region: {region}"
-        )
+        self.logger.info(f"Initialized Huawei Cloud Agent Identity client for region: {region}")
 
     @staticmethod
-    def _should_retry(
-        resp: SdkResponse | None, exception: SdkException | None
-    ) -> bool:
+    def _should_retry(resp: SdkResponse | None, exception: SdkException | None) -> bool:
         """Determines if a request should be retried based on response or exception.
 
         Retries on:
@@ -178,8 +190,7 @@ class IdentityClient:
             request=CreateWorkloadIdentityRequest(
                 body=CreateWorkloadIdentityReqBody(
                     name=name,
-                    allowed_resource_oauth2_return_urls=allowed_resource_oauth2_return_urls
-                    or [],
+                    allowed_resource_oauth2_return_urls=allowed_resource_oauth2_return_urls or [],
                     authorizer_type=authorizer_type,
                     authorizer_configuration=authorizer_configuration,
                 )
@@ -237,9 +248,7 @@ class IdentityClient:
         response: CreateApiKeyCredentialProviderResponse = (
             self.client.create_api_key_credential_provider(
                 request=CreateApiKeyCredentialProviderRequest(
-                    body=CreateApiKeyCredentialProviderReqBody(
-                        name=name, api_key=api_key
-                    )
+                    body=CreateApiKeyCredentialProviderReqBody(name=name, api_key=api_key)
                 )
             )
         )
@@ -278,15 +287,11 @@ class IdentityClient:
 
         if vendor == OAuth2Vendor.GITHUBOAUTH2:
             config = Oauth2ProviderConfigInput(
-                github_oauth2_provider_config=GithubOauth2ProviderConfigInput(
-                    **config_kwargs
-                )
+                github_oauth2_provider_config=GithubOauth2ProviderConfigInput(**config_kwargs)
             )
         elif vendor == OAuth2Vendor.GOOGLEOAUTH2:
             config = Oauth2ProviderConfigInput(
-                google_oauth2_provider_config=GoogleOauth2ProviderConfigInput(
-                    **config_kwargs
-                )
+                google_oauth2_provider_config=GoogleOauth2ProviderConfigInput(**config_kwargs)
             )
         elif vendor == OAuth2Vendor.MICROSOFTOAUTH2:
             config = Oauth2ProviderConfigInput(
@@ -336,13 +341,9 @@ class IdentityClient:
         """
         self.logger.info(f"Creating STS credential provider: {name}")
 
-        response: CreateStsCredentialProviderResponse = (
-            self.client.create_sts_credential_provider(
-                request=CreateStsCredentialProviderRequest(
-                    body=CreateStsCredentialProviderReqBody(
-                        name=name, agency_urn=agency_urn, tags=tags
-                    )
-                )
+        response: CreateStsCredentialProviderResponse = self.client.create_sts_credential_provider(
+            request=CreateStsCredentialProviderRequest(
+                body=CreateStsCredentialProviderReqBody(name=name, agency_urn=agency_urn, tags=tags)
             )
         )
         return response.credential_provider
@@ -365,9 +366,7 @@ class IdentityClient:
         """
         if user_token:
             if user_id is not None:
-                self.logger.warning(
-                    "Both user token and user id are supplied, using user token"
-                )
+                self.logger.warning("Both user token and user id are supplied, using user token")
             self.logger.info("Getting workload access token for JWT...")
             # Create request for JWT-based token
             invoker = self.client.create_workload_access_token_for_jwt_invoker(
@@ -402,9 +401,7 @@ class IdentityClient:
             # Create basic workload access token request
             invoker = self.client.create_workload_access_token_invoker(
                 request=CreateWorkloadAccessTokenRequest(
-                    body=CreateWorkloadAccessTokenRequestBody(
-                        workload_name=workload_name
-                    )
+                    body=CreateWorkloadAccessTokenRequestBody(workload_name=workload_name)
                 )
             )
             resp: CreateWorkloadAccessTokenResponse = invoker.with_retry(
@@ -415,6 +412,121 @@ class IdentityClient:
 
         self.logger.info("Successfully retrieved workload access token")
         return resp.workload_access_token
+
+    def get_api_key_credential_provider(self, name: str) -> ApiKeyCredentialProvider:
+        """Gets a specified API key credential provider.
+
+        Args:
+            name: The name of the credential provider.
+
+        Returns:
+            The ApiKeyCredentialProvider object.
+        """
+        self.logger.info(f"Getting API key credential provider: {name}")
+
+        response: GetApiKeyCredentialProviderResponse = self.client.get_api_key_credential_provider(
+            request=GetApiKeyCredentialProviderRequest(credential_provider_name=name)
+        )
+        return response.credential_provider
+
+    def list_api_key_credential_providers(
+        self,
+        limit: int | None = None,
+        marker: str | None = None,
+    ) -> list[ApiKeyCredentialProviderSummary]:
+        """Lists all API key credential providers.
+
+        Args:
+            limit: Optional limit for pagination.
+            marker: Optional marker for pagination.
+
+        Returns:
+            A list of ApiKeyCredentialProviderSummary objects.
+        """
+        self.logger.info("Listing API key credential providers...")
+
+        response: ListApiKeyCredentialProvidersResponse = (
+            self.client.list_api_key_credential_providers(
+                request=ListApiKeyCredentialProvidersRequest(limit=limit, marker=marker)
+            )
+        )
+        return response.credential_providers or []
+
+    def get_oauth2_credential_provider(self, name: str) -> Oauth2CredentialProvider:
+        """Gets a specified OAuth2 credential provider.
+
+        Args:
+            name: The name of the credential provider.
+
+        Returns:
+            The Oauth2CredentialProvider object.
+        """
+        self.logger.info(f"Getting OAuth2 credential provider: {name}")
+
+        response: GetOauth2CredentialProviderResponse = self.client.get_oauth2_credential_provider(
+            request=GetOauth2CredentialProviderRequest(credential_provider_name=name)
+        )
+        return response.credential_provider
+
+    def list_oauth2_credential_providers(
+        self,
+        limit: int | None = None,
+        marker: str | None = None,
+    ) -> list[Oauth2CredentialProviderSummary]:
+        """Lists all OAuth2 credential providers.
+
+        Args:
+            limit: Optional limit for pagination.
+            marker: Optional marker for pagination.
+
+        Returns:
+            A list of Oauth2CredentialProviderSummary objects.
+        """
+        self.logger.info("Listing OAuth2 credential providers...")
+
+        response: ListOauth2CredentialProvidersResponse = (
+            self.client.list_oauth2_credential_providers(
+                request=ListOauth2CredentialProvidersRequest(limit=limit, marker=marker)
+            )
+        )
+        return response.credential_providers or []
+
+    def get_sts_credential_provider(self, name: str) -> StsCredentialProvider:
+        """Gets a specified STS credential provider.
+
+        Args:
+            name: The name of the credential provider.
+
+        Returns:
+            The StsCredentialProvider object.
+        """
+        self.logger.info(f"Getting STS credential provider: {name}")
+
+        response: GetStsCredentialProviderResponse = self.client.get_sts_credential_provider(
+            request=GetStsCredentialProviderRequest(credential_provider_name=name)
+        )
+        return response.credential_provider
+
+    def list_sts_credential_providers(
+        self,
+        limit: int | None = None,
+        marker: str | None = None,
+    ) -> list[StsCredentialProviderSummary]:
+        """Lists all STS credential providers.
+
+        Args:
+            limit: Optional limit for pagination.
+            marker: Optional marker for pagination.
+
+        Returns:
+            A list of StsCredentialProviderSummary objects.
+        """
+        self.logger.info("Listing STS credential providers...")
+
+        response: ListStsCredentialProvidersResponse = self.client.list_sts_credential_providers(
+            request=ListStsCredentialProvidersRequest(limit=limit, marker=marker)
+        )
+        return response.credential_providers or []
 
     async def get_resource_oauth2_token(
         self,
@@ -515,13 +627,9 @@ class IdentityClient:
             return await active_poller.poll_for_token()
 
         msg = "Identity service did not return a token or an authorization URL."
-        raise RuntimeError(
-            msg
-        )
+        raise RuntimeError(msg)
 
-    def get_resource_api_key(
-        self, *, provider_name: str, workload_access_token: str
-    ) -> str:
+    def get_resource_api_key(self, *, provider_name: str, workload_access_token: str) -> str:
         """Programmatically retrieves an API key from the Identity service.
 
         Args:
@@ -616,12 +724,10 @@ class IdentityClient:
         """
         self.logger.info("Completing 3LO OAuth2 flow...")
 
-        response: CompleteResourceTokenAuthResponse = (
-            self.client.complete_resource_token_auth(
-                request=CompleteResourceTokenAuthRequest(
-                    body=CompleteResourceTokenAuthRequestBody(
-                        user_identifier=user_identifier, session_uri=session_uri
-                    )
+        response: CompleteResourceTokenAuthResponse = self.client.complete_resource_token_auth(
+            request=CompleteResourceTokenAuthRequest(
+                body=CompleteResourceTokenAuthRequestBody(
+                    user_identifier=user_identifier, session_uri=session_uri
                 )
             )
         )

--- a/tests/unit/sdk/service/identity/test_credential_providers.py
+++ b/tests/unit/sdk/service/identity/test_credential_providers.py
@@ -49,16 +49,12 @@ def test_create_api_key_credential_provider_success(
     api_key = "test-api-key"
 
     # WHEN
-    result = identity_client.create_api_key_credential_provider(
-        name=name, api_key=api_key
-    )
+    result = identity_client.create_api_key_credential_provider(name=name, api_key=api_key)
 
     # THEN
     assert result == mock_provider
     mock_sdk_client.create_api_key_credential_provider.assert_called_once()
-    request = mock_sdk_client.create_api_key_credential_provider.call_args.kwargs[
-        "request"
-    ]
+    request = mock_sdk_client.create_api_key_credential_provider.call_args.kwargs["request"]
     assert request.body.name == name
     assert request.body.api_key == api_key
 
@@ -88,9 +84,7 @@ def test_create_oauth2_credential_provider_google_success(
     # THEN
     assert result == mock_provider
     mock_sdk_client.create_oauth2_credential_provider.assert_called_once()
-    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs[
-        "request"
-    ]
+    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs["request"]
     assert request.body.name == name
     assert request.body.credential_provider_vendor == vendor
     assert (
@@ -130,9 +124,7 @@ def test_create_oauth2_credential_provider_with_tags(
     # THEN
     assert result == mock_provider
     mock_sdk_client.create_oauth2_credential_provider.assert_called_once()
-    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs[
-        "request"
-    ]
+    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs["request"]
     assert request.body.name == name
     assert request.body.credential_provider_vendor == vendor
     assert request.body.tags == tags
@@ -165,9 +157,7 @@ def test_create_oauth2_credential_provider_microsoft_success(
     # THEN
     assert result == mock_provider
     mock_sdk_client.create_oauth2_credential_provider.assert_called_once()
-    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs[
-        "request"
-    ]
+    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs["request"]
     assert request.body.name == name
     assert request.body.credential_provider_vendor == vendor
     assert (
@@ -215,9 +205,7 @@ def test_create_oauth2_credential_provider_custom_success(
     # THEN
     assert result == mock_provider
     mock_sdk_client.create_oauth2_credential_provider.assert_called_once()
-    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs[
-        "request"
-    ]
+    request = mock_sdk_client.create_oauth2_credential_provider.call_args.kwargs["request"]
     assert request.body.name == name
     assert request.body.credential_provider_vendor == vendor
     assert (
@@ -228,3 +216,120 @@ def test_create_oauth2_credential_provider_custom_success(
         request.body.oauth2_provider_config_input.custom_oauth2_provider_config.client_id
         == client_id
     )
+
+
+def test_get_api_key_credential_provider(
+    identity_client: IdentityClient, mock_sdk_client: MagicMock
+) -> None:
+    from huaweicloudsdkagentidentity.v1 import GetApiKeyCredentialProviderResponse
+
+    mock_provider = MagicMock(spec=ApiKeyCredentialProvider)
+    mock_response = MagicMock(spec=GetApiKeyCredentialProviderResponse)
+    mock_response.credential_provider = mock_provider
+    mock_sdk_client.get_api_key_credential_provider.return_value = mock_response
+
+    result = identity_client.get_api_key_credential_provider(name="test-provider")
+
+    assert result == mock_provider
+    mock_sdk_client.get_api_key_credential_provider.assert_called_once()
+    request = mock_sdk_client.get_api_key_credential_provider.call_args.kwargs["request"]
+    assert request.credential_provider_name == "test-provider"
+
+
+def test_list_api_key_credential_providers(
+    identity_client: IdentityClient, mock_sdk_client: MagicMock
+) -> None:
+    from huaweicloudsdkagentidentity.v1 import (
+        ApiKeyCredentialProviderSummary,
+        ListApiKeyCredentialProvidersResponse,
+    )
+
+    mock_provider = MagicMock(spec=ApiKeyCredentialProviderSummary)
+    mock_response = MagicMock(spec=ListApiKeyCredentialProvidersResponse)
+    mock_response.credential_providers = [mock_provider]
+    mock_sdk_client.list_api_key_credential_providers.return_value = mock_response
+
+    result = identity_client.list_api_key_credential_providers(limit=10, marker="token")
+
+    assert result == [mock_provider]
+    mock_sdk_client.list_api_key_credential_providers.assert_called_once()
+    request = mock_sdk_client.list_api_key_credential_providers.call_args.kwargs["request"]
+    assert request.limit == 10
+    assert request.marker == "token"
+
+
+def test_get_oauth2_credential_provider(
+    identity_client: IdentityClient, mock_sdk_client: MagicMock
+) -> None:
+    from huaweicloudsdkagentidentity.v1 import GetOauth2CredentialProviderResponse
+
+    mock_provider = MagicMock(spec=Oauth2CredentialProvider)
+    mock_response = MagicMock(spec=GetOauth2CredentialProviderResponse)
+    mock_response.credential_provider = mock_provider
+    mock_sdk_client.get_oauth2_credential_provider.return_value = mock_response
+
+    result = identity_client.get_oauth2_credential_provider(name="test-provider")
+
+    assert result == mock_provider
+    mock_sdk_client.get_oauth2_credential_provider.assert_called_once()
+    request = mock_sdk_client.get_oauth2_credential_provider.call_args.kwargs["request"]
+    assert request.credential_provider_name == "test-provider"
+
+
+def test_list_oauth2_credential_providers(
+    identity_client: IdentityClient, mock_sdk_client: MagicMock
+) -> None:
+    from huaweicloudsdkagentidentity.v1 import (
+        ListOauth2CredentialProvidersResponse,
+        Oauth2CredentialProviderSummary,
+    )
+
+    mock_provider = MagicMock(spec=Oauth2CredentialProviderSummary)
+    mock_response = MagicMock(spec=ListOauth2CredentialProvidersResponse)
+    mock_response.credential_providers = [mock_provider]
+    mock_sdk_client.list_oauth2_credential_providers.return_value = mock_response
+
+    result = identity_client.list_oauth2_credential_providers()
+
+    assert result == [mock_provider]
+    mock_sdk_client.list_oauth2_credential_providers.assert_called_once()
+
+
+def test_get_sts_credential_provider(
+    identity_client: IdentityClient, mock_sdk_client: MagicMock
+) -> None:
+    from huaweicloudsdkagentidentity.v1 import (
+        GetStsCredentialProviderResponse,
+        StsCredentialProvider,
+    )
+
+    mock_provider = MagicMock(spec=StsCredentialProvider)
+    mock_response = MagicMock(spec=GetStsCredentialProviderResponse)
+    mock_response.credential_provider = mock_provider
+    mock_sdk_client.get_sts_credential_provider.return_value = mock_response
+
+    result = identity_client.get_sts_credential_provider(name="test-provider")
+
+    assert result == mock_provider
+    mock_sdk_client.get_sts_credential_provider.assert_called_once()
+    request = mock_sdk_client.get_sts_credential_provider.call_args.kwargs["request"]
+    assert request.credential_provider_name == "test-provider"
+
+
+def test_list_sts_credential_providers(
+    identity_client: IdentityClient, mock_sdk_client: MagicMock
+) -> None:
+    from huaweicloudsdkagentidentity.v1 import (
+        ListStsCredentialProvidersResponse,
+        StsCredentialProviderSummary,
+    )
+
+    mock_provider = MagicMock(spec=StsCredentialProviderSummary)
+    mock_response = MagicMock(spec=ListStsCredentialProvidersResponse)
+    mock_response.credential_providers = [mock_provider]
+    mock_sdk_client.list_sts_credential_providers.return_value = mock_response
+
+    result = identity_client.list_sts_credential_providers()
+
+    assert result == [mock_provider]
+    mock_sdk_client.list_sts_credential_providers.assert_called_once()

--- a/tests/unit/sdk/service/identity/test_workload_identities.py
+++ b/tests/unit/sdk/service/identity/test_workload_identities.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock, patch
+
+from huaweicloudsdkagentidentity.v1 import (
+    AgentIdentityClient,
+    GetWorkloadIdentityResponse,
+    ListWorkloadIdentitiesResponse,
+    WorkloadIdentity,
+    WorkloadIdentitySummary,
+)
+
+from agentarts.sdk.service.identity.identity_client import IdentityClient
+
+
+def _build_identity_client(mock_sdk_client: MagicMock) -> IdentityClient:
+    with patch.dict(
+        "os.environ",
+        {
+            "HUAWEICLOUD_SDK_AK": "test-ak",
+            "HUAWEICLOUD_SDK_SK": "test-sk",
+            "HUAWEICLOUD_SDK_PROJECT_ID": "test-project",
+            "HUAWEICLOUD_SDK_REGION": "ap-southeast-4",
+            "HUAWEICLOUD_SDK_DOMAIN_ID": "test-domain",
+        },
+    ):
+        return IdentityClient(region="ap-southeast-4", client=mock_sdk_client)
+
+
+def test_get_workload_identity_success() -> None:
+    # GIVEN
+    mock_sdk_client = MagicMock(spec=AgentIdentityClient)
+    identity_client = _build_identity_client(mock_sdk_client)
+    mock_workload = MagicMock(spec=WorkloadIdentity)
+    mock_response = MagicMock(spec=GetWorkloadIdentityResponse)
+    mock_response.workload_identity = mock_workload
+    mock_sdk_client.get_workload_identity.return_value = mock_response
+
+    name = "test-workload"
+
+    # WHEN
+    result = identity_client.get_workload_identity(name=name)
+
+    # THEN
+    assert result == mock_workload
+    mock_sdk_client.get_workload_identity.assert_called_once()
+    request = mock_sdk_client.get_workload_identity.call_args.kwargs["request"]
+    assert request.workload_identity_name == name
+
+
+def test_list_workload_identities_success() -> None:
+    # GIVEN
+    mock_sdk_client = MagicMock(spec=AgentIdentityClient)
+    identity_client = _build_identity_client(mock_sdk_client)
+    mock_workloads = [
+        MagicMock(spec=WorkloadIdentitySummary),
+        MagicMock(spec=WorkloadIdentitySummary),
+    ]
+    mock_response = MagicMock(spec=ListWorkloadIdentitiesResponse)
+    mock_response.workload_identities = mock_workloads
+    mock_sdk_client.list_workload_identities.return_value = mock_response
+
+    # WHEN
+    result = identity_client.list_workload_identities(limit=10, marker="next-page")
+
+    # THEN
+    assert result == mock_workloads
+    mock_sdk_client.list_workload_identities.assert_called_once()
+    request = mock_sdk_client.list_workload_identities.call_args.kwargs["request"]
+    assert request.limit == 10
+    assert request.marker == "next-page"
+
+
+def test_list_workload_identities_returns_empty_list_when_response_is_empty() -> None:
+    # GIVEN
+    mock_sdk_client = MagicMock(spec=AgentIdentityClient)
+    identity_client = _build_identity_client(mock_sdk_client)
+    mock_response = MagicMock(spec=ListWorkloadIdentitiesResponse)
+    mock_response.workload_identities = None
+    mock_sdk_client.list_workload_identities.return_value = mock_response
+
+    # WHEN
+    result = identity_client.list_workload_identities()
+
+    # THEN
+    assert result == []
+    mock_sdk_client.list_workload_identities.assert_called_once()
+    request = mock_sdk_client.list_workload_identities.call_args.kwargs["request"]
+    assert request.limit is None
+    assert request.marker is None

--- a/uv.lock
+++ b/uv.lock
@@ -19,11 +19,12 @@ resolution-markers = [
 
 [[package]]
 name = "agentarts-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "docker" },
+    { name = "httpx" },
     { name = "huaweicloudsdkagentidentity" },
     { name = "huaweicloudsdkiam" },
     { name = "huaweicloudsdkswr" },
@@ -114,7 +115,6 @@ web = [
 dev = [
     { name = "black" },
     { name = "flake8" },
-    { name = "httpx" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -135,6 +135,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.104.0" },
+    { name = "httpx", specifier = ">=0.25.0" },
     { name = "huaweicloudsdkagentidentity", specifier = ">=3.1.0" },
     { name = "huaweicloudsdkiam", specifier = ">=3.1.0" },
     { name = "huaweicloudsdkobs", marker = "extra == 'huaweicloud'", specifier = ">=3.1.0" },
@@ -174,7 +175,6 @@ provides-extras = ["web", "langchain", "langgraph", "autogen", "crewai", "vector
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "flake8", specifier = ">=6.1.0" },
-    { name = "httpx", specifier = ">=0.25.0" },
     { name = "isort", specifier = ">=5.12.0" },
     { name = "mypy", specifier = ">=1.5.0" },
     { name = "pre-commit", specifier = ">=3.5.0" },


### PR DESCRIPTION
Fixes https://github.com/huaweicloud/agentarts-sdk-python/issues/21

## Summary
- Exposes `get` and `list` helpers for OAuth2, API key, and STS credential providers in `IdentityClient`.
- Adds workload identity query helpers: `get_workload_identity(name)` and `list_workload_identities(limit=None, marker=None)`.
- Delegates to the generated Huawei Cloud Agent Identity SDK request/response models and normalizes empty list responses to `[]`.

## Tests
- `.venv\Scripts\python.exe -m pytest tests\unit\sdk\service\identity`
- `.venv\Scripts\python.exe -m ruff check src\agentarts\sdk\service\identity\identity_client.py tests\unit\sdk\service\identity\test_workload_identities.py`