### PR TITLE
fix(memory): fix resource leaks and timeout configuration

### DIFF
--- a/src/agentarts/sdk/memory/session.py
+++ b/src/agentarts/sdk/memory/session.py
@@ -419,3 +419,23 @@ class MemorySession:
         """
         logger.info(f"Deleting memory record: {memory_id}")
         self._data_plane.delete_memory(self.space_id, memory_id)
+
+    def close(self) -> None:
+        """
+        Close the session and release resources.
+        """
+        if hasattr(self, "_data_plane") and self._data_plane is not None:
+            self._data_plane.close()
+            logger.info("MemorySession closed")
+
+    def __enter__(self) -> "MemorySession":
+        """
+        Enter the runtime context of the session.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Exit the runtime context of the session.
+        """
+        self.close()

--- a/src/agentarts/sdk/service/memory_service.py
+++ b/src/agentarts/sdk/service/memory_service.py
@@ -332,7 +332,7 @@ class MemoryHttpService:
                 data=text_data,
                 headers=final_headers,
                 verify=self.verify_ssl,
-                timeout=60
+                timeout=self.timeout
             )
 
             if response.status_code in {200, 201}:


### PR DESCRIPTION
## Summary

Code review findings from a systematic read-through of the `src/agentarts/sdk/memory` and `src/agentarts/sdk/service` modules. This PR addresses core bugs related to resource management and timeout configuration.

### Bug fixes
- **`session.py`** — `MemorySession` lacked `close()`/`__enter__`/`__exit__` (parity gap vs `AsyncMemorySession` which has them at lines 238-251). Added, releasing the underlying `_DataPlane` HTTP session.
- **`memory_service.py:335`** — Hardcoded `timeout=60` ignored the configured `self.timeout`. Now passes `self.timeout`.

## Tests
- [x] `uv run ruff check src/agentarts/sdk/memory src/agentarts/sdk/service`
- [x] `uv run ruff format --check src/agentarts/sdk/memory src/agentarts/sdk/service`
- [x] Manual: instantiate `MemorySession`, use `with MemorySession.of(...) as s:`, verify close() releases HTTP session
