### PR TITLE
fix(memory): align type annotations and correct region attribute references in async client

### DIFF
--- a/src/agentarts/sdk/memory/async_client.py
+++ b/src/agentarts/sdk/memory/async_client.py
@@ -126,7 +126,7 @@ class AsyncMemoryClient:
 
     def get_space(self, space_id: str) -> SpaceInfo:
         """Get Space details - identical to sync version."""
-        self._ensure_control_plane_initialized(self._async_data_plane.client.region_name)
+        self._ensure_control_plane_initialized(self.region_name)
         return self._control_plane.get_space(space_id)
 
     def list_spaces(
@@ -135,7 +135,7 @@ class AsyncMemoryClient:
             offset: int = 0
     ) -> SpaceListResponse:
         """List all Spaces - identical to sync version."""
-        self._ensure_control_plane_initialized(self._async_data_plane.client.region_name)
+        self._ensure_control_plane_initialized(self.region_name)
         return self._control_plane.list_spaces(limit, offset)
 
     def update_space(
@@ -164,12 +164,12 @@ class AsyncMemoryClient:
             memory_strategies_builtin=memory_strategies_builtin
         )
 
-        self._ensure_control_plane_initialized(self._async_data_plane.client.region_name)
+        self._ensure_control_plane_initialized(self.region_name)
         return self._control_plane.update_space(space_id, request)
 
     def delete_space(self, space_id: str) -> None:
         """Delete Space - identical to sync version."""
-        self._ensure_control_plane_initialized(self._async_data_plane.client.region_name)
+        self._ensure_control_plane_initialized(self.region_name)
         return self._control_plane.delete_space(space_id)
 
     # ==================== Data Plane - Session Management (Async) ====================

--- a/src/agentarts/sdk/memory/inner/dataplane.py
+++ b/src/agentarts/sdk/memory/inner/dataplane.py
@@ -174,7 +174,7 @@ class _DataPlane:
             message_id: str,
             space_id: str,
             session_id: str
-    ) -> dict[str, Any]:
+    ) -> MessageInfo:
         """
         Get single message.
 


### PR DESCRIPTION
This pull request makes several fixes and improvements to the async memory client and data plane code, primarily focusing on how region information is accessed and how message data is returned. The most important changes are:

**Region Initialization Consistency:**
* Updated all methods in `async_client.py` (`get_space`, `list_spaces`, `update_space`, and `delete_space`) to use the `self.region_name` attribute instead of accessing the region via the internal data plane client. This simplifies and standardizes how region information is referenced throughout the class, Aligned with sync version.

**Type Consistency in Data Plane:**
* Changed the return type of `get_message` in `inner/dataplane.py` from a generic `dict[str, Any]` to the more specific `MessageInfo` type, improving type safety and clarity, matching the async version.

## Verification

* $ uv run ruff check src/agentarts/sdk/memory src/agentarts/sdk/service
All checks passed!
* Verification demo: The get_message method (in `inner/dataplane.py`) is called to return a `MessageInfo` instance (not a dict). The four control plane methods (`get_space`, `list_spaces`, `update_space`, and `delete_space`) of `AsyncMemoryClient` are all initialized using `self.region_name`, which is the same as that of `MemoryClient`.
