### PR TITLE
feat(memory): add delete_session API support

### DIFF
--- a/src/agentarts/sdk/memory/async_client.py
+++ b/src/agentarts/sdk/memory/async_client.py
@@ -192,6 +192,10 @@ class AsyncMemoryClient:
 
         return await self._async_data_plane.create_memory_session(space_id, session_request)
 
+    async def delete_session(self, space_id: str, session_id: str) -> None:
+        """Delete a session (soft delete) - identical to sync version."""
+        await self._async_data_plane.delete_session(space_id, session_id)
+
     # ==================== Data Plane - Message Management (Async) ====================
 
     async def get_last_k_messages(

--- a/src/agentarts/sdk/memory/async_session.py
+++ b/src/agentarts/sdk/memory/async_session.py
@@ -133,10 +133,8 @@ class AsyncMemorySession:
 
     async def delete(self) -> None:
         """Delete this session (soft delete) - identical to sync version."""
-        logger.info(f"Deleting session: {self.session_id} in space: {self.space_id}")
         await self._async_data_plane.delete_session(self.space_id, self.session_id)
-        logger.info(f"Session deleted: {self.session_id}")
-        logger.info("After deletion, this session object should not be used for further operations.")
+        logger.info(f"Session deleted: {self.session_id} in space: {self.space_id}")
 
     # ==================== Message Management (Async) ====================
 

--- a/src/agentarts/sdk/memory/async_session.py
+++ b/src/agentarts/sdk/memory/async_session.py
@@ -131,6 +131,13 @@ class AsyncMemorySession:
         """Get region name."""
         return self._region_name
 
+    async def delete(self) -> None:
+        """Delete this session (soft delete) - identical to sync version."""
+        logger.info(f"Deleting session: {self.session_id} in space: {self.space_id}")
+        await self._async_data_plane.delete_session(self.space_id, self.session_id)
+        logger.info(f"Session deleted: {self.session_id}")
+        logger.info("After deletion, this session object should not be used for further operations.")
+
     # ==================== Message Management (Async) ====================
 
     async def get_last_k_messages(

--- a/src/agentarts/sdk/memory/client.py
+++ b/src/agentarts/sdk/memory/client.py
@@ -497,6 +497,22 @@ class MemoryClient:
 
         return self._data_plane.create_memory_session(space_id, session_request)
 
+    def delete_session(self, space_id: str, session_id: str) -> None:
+        """
+        Delete a session (soft delete).
+
+        Soft-deletes the specified session. Associated messages and memories are
+        cleaned up asynchronously by the backend (90-365 days per space config).
+
+        Args:
+            space_id: Space ID
+            session_id: Session ID to delete
+
+        Examples:
+            >>> client.delete_session("space-123", "session-456")
+        """
+        self._data_plane.delete_session(space_id, session_id)
+
     # ==================== Data Plane - Message Management ====================
 
     def get_last_k_messages(

--- a/src/agentarts/sdk/memory/inner/dataplane.py
+++ b/src/agentarts/sdk/memory/inner/dataplane.py
@@ -112,9 +112,8 @@ class _DataPlane:
             msg = "session_id is required for delete operation"
             raise ValueError(msg)
 
-        logger.info(f"Deleting session: {session_id} in space: {space_id}")
         self.client.delete_session(space_id, session_id)
-        logger.info(f"Session deleted: {session_id}")
+        logger.info(f"Session deleted: {session_id} in space: {space_id}")
 
     def add_messages(
             self,

--- a/src/agentarts/sdk/memory/inner/dataplane.py
+++ b/src/agentarts/sdk/memory/inner/dataplane.py
@@ -96,6 +96,26 @@ class _DataPlane:
         logger.info(f"Memory session created: {result.get('id')}")
         return SessionInfo.from_dict(result)
 
+    def delete_session(self, space_id: str, session_id: str) -> None:
+        """
+        Delete a session (soft delete).
+
+        Args:
+            space_id: Space ID
+            session_id: Session ID to delete
+        """
+        if not space_id:
+            msg = "space_id is required for data plane operations"
+            raise ValueError(msg)
+
+        if not session_id:
+            msg = "session_id is required for delete operation"
+            raise ValueError(msg)
+
+        logger.info(f"Deleting session: {session_id} in space: {space_id}")
+        self.client.delete_session(space_id, session_id)
+        logger.info(f"Session deleted: {session_id}")
+
     def add_messages(
             self,
             space_id: str,

--- a/src/agentarts/sdk/memory/inner/dataplane_async.py
+++ b/src/agentarts/sdk/memory/inner/dataplane_async.py
@@ -100,9 +100,8 @@ class _AsyncDataPlane:
             msg = "session_id is required for delete operation"
             raise ValueError(msg)
 
-        logger.info(f"Deleting session: {session_id} in space: {space_id}")
         await self.client.delete_session(space_id, session_id)
-        logger.info(f"Session deleted: {session_id}")
+        logger.info(f"Session deleted: {session_id} in space: {space_id}")
 
     async def add_messages(
             self,

--- a/src/agentarts/sdk/memory/inner/dataplane_async.py
+++ b/src/agentarts/sdk/memory/inner/dataplane_async.py
@@ -84,6 +84,26 @@ class _AsyncDataPlane:
         logger.info(f"Memory session created: {result.get('id')}")
         return SessionInfo.from_dict(result)
 
+    async def delete_session(self, space_id: str, session_id: str) -> None:
+        """
+        Delete a session (soft delete) - identical to sync version.
+
+        Args:
+            space_id: Space ID
+            session_id: Session ID to delete
+        """
+        if not space_id:
+            msg = "space_id is required for data plane operations"
+            raise ValueError(msg)
+
+        if not session_id:
+            msg = "session_id is required for delete operation"
+            raise ValueError(msg)
+
+        logger.info(f"Deleting session: {session_id} in space: {space_id}")
+        await self.client.delete_session(space_id, session_id)
+        logger.info(f"Session deleted: {session_id}")
+
     async def add_messages(
             self,
             space_id: str,

--- a/src/agentarts/sdk/memory/session.py
+++ b/src/agentarts/sdk/memory/session.py
@@ -212,10 +212,8 @@ class MemorySession:
             >>> session = MemorySession(space_id="space-123", actor_id="user-456")
             >>> session.delete()
         """
-        logger.info(f"Deleting session: {self.session_id} in space: {self.space_id}")
         self._data_plane.delete_session(self.space_id, self.session_id)
-        logger.info(f"Session deleted: {self.session_id}")
-        logger.info("After deletion, this session object should not be used for further operations.")
+        logger.info(f"Session deleted: {self.session_id} in space: {self.space_id}")
 
     # ==================== Message Management ====================
 

--- a/src/agentarts/sdk/memory/session.py
+++ b/src/agentarts/sdk/memory/session.py
@@ -200,6 +200,23 @@ class MemorySession:
         """
         return f"MemorySession(space_id='{self.space_id}', session_id='{self.session_id}', region_name='{self._region_name}')"
 
+    def delete(self) -> None:
+        """
+        Delete this session (soft delete).
+
+        Soft-deletes the current session. Associated messages and memories are
+        cleaned up asynchronously by the backend (90-365 days per space config).
+        After deletion, this session object should not be used for further operations.
+
+        Examples:
+            >>> session = MemorySession(space_id="space-123", actor_id="user-456")
+            >>> session.delete()
+        """
+        logger.info(f"Deleting session: {self.session_id} in space: {self.space_id}")
+        self._data_plane.delete_session(self.space_id, self.session_id)
+        logger.info(f"Session deleted: {self.session_id}")
+        logger.info("After deletion, this session object should not be used for further operations.")
+
     # ==================== Message Management ====================
 
     def get_last_k_messages(

--- a/src/agentarts/sdk/service/memory_service.py
+++ b/src/agentarts/sdk/service/memory_service.py
@@ -461,6 +461,19 @@ class MemoryHttpService:
             space_id=space_id
         )
 
+    def delete_session(self, space_id: str, session_id: str) -> None:
+        """Delete a session (soft delete).
+
+        Args:
+            space_id: Space ID
+            session_id: Session ID
+        """
+        self._make_request(
+            method="DELETE",
+            path=f"/v1/core/spaces/{space_id}/sessions/{session_id}",
+            space_id=space_id
+        )
+
     def add_messages(
             self,
             space_id: str,

--- a/src/agentarts/sdk/service/memory_service_async.py
+++ b/src/agentarts/sdk/service/memory_service_async.py
@@ -359,6 +359,14 @@ class AsyncMemoryHttpService:
             space_id=space_id
         )
 
+    async def delete_session(self, space_id: str, session_id: str) -> None:
+        """Delete a session (soft delete) - identical to sync version."""
+        await self._make_request(
+            method="DELETE",
+            path=f"/v1/core/spaces/{space_id}/sessions/{session_id}",
+            space_id=space_id
+        )
+
     async def add_messages(
             self,
             space_id: str,


### PR DESCRIPTION
## Summary

- Add `delete_session` API across all layers (service, dataplane, client, session) for both sync and async variants
- Expose `delete()` convenience method on `MemorySession` and `AsyncMemorySession`

## Changed Files

| File | Changes |
|------|---------|
| `src/agentarts/sdk/service/memory_service.py` | Add `delete_session()` method |
| `src/agentarts/sdk/service/memory_service_async.py` | Add async `delete_session()` |
| `src/agentarts/sdk/memory/inner/dataplane.py` | Add `delete_session()` method |
| `src/agentarts/sdk/memory/inner/dataplane_async.py` | Add async `delete_session()` method |
| `src/agentarts/sdk/memory/client.py` | Expose `delete_session()` in `MemoryClient` |
| `src/agentarts/sdk/memory/async_client.py` | Expose `delete_session()` in `AsyncMemoryClient` |
| `src/agentarts/sdk/memory/session.py` | Add `delete()` convenience method |
| `src/agentarts/sdk/memory/async_session.py` | Add `delete()` convenience method |

## Verification

A test script was created that provisions a shared Space with the summary strategy, then exercises the delete_session functionality across three API surfaces: the synchronous MemoryClient, the MemorySession convenience wrapper, and the asynchronous AsyncMemoryClient. For each surface, a session is created, optionally populated with a message, and then deleted via the corresponding delete method. The test confirms that all three deletion paths complete without error and that the soft-delete behavior is consistent across sync and async variants.
