### PR TITLE
feat(integration): add navigation agent demo with LangGraph + AgentArts Memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,9 @@ test-results/
 # Docker
 *.dockerignore
 
+# Demo local data
+examples/navigation_langgraph_memory/sessions.json
+
 # Temporary files
 *.tmp
 *.temp

--- a/examples/navigation_langgraph_memory/.env.example
+++ b/examples/navigation_langgraph_memory/.env.example
@@ -2,8 +2,8 @@
 # Copy this file to .env and fill in your values.
 
 # --- AgentArts Memory SDK Endpoints ---
-# Default control endpoint (public cloud). Override for internal network.
-AGENTARTS_CONTROL_ENDPOINT=https://agentarts.myhuaweicloud.com
+# Default control endpoint (SW-Guiyang-1 region). Override for internal network.
+AGENTARTS_CONTROL_ENDPOINT=https://agentarts.cn-southwest-2.myhuaweicloud.com
 # Data endpoint must be set if using internal network
 AGENTARTS_MEMORY_DATA_ENDPOINT=
 

--- a/examples/navigation_langgraph_memory/.env.example
+++ b/examples/navigation_langgraph_memory/.env.example
@@ -1,0 +1,25 @@
+# AgentArts Navigation Agent Demo - Environment Variables
+# Copy this file to .env and fill in your values.
+
+# --- AgentArts Memory SDK Endpoints ---
+# Default control endpoint (public cloud). Override for internal network.
+AGENTARTS_CONTROL_ENDPOINT=https://agentarts.myhuaweicloud.com
+# Data endpoint must be set if using internal network
+AGENTARTS_MEMORY_DATA_ENDPOINT=
+
+# --- SSL Verification ---
+# Set to false for internal network testing with self-signed certs
+VERIFY_SSL=true
+
+# --- AgentArts Memory SDK ---
+# Run setup_memory.py first, then paste the printed values here.
+AGENTARTS_MEMORY_SPACE_ID=
+HUAWEICLOUD_SDK_MEMORY_API_KEY=
+
+# --- LLM Configuration (OpenAI-compatible) ---
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+OPENAI_MODEL_NAME=deepseek-v3.2
+
+# --- AMap (optional, mock data used if not set) ---
+AMAP_KEY=

--- a/examples/navigation_langgraph_memory/README.md
+++ b/examples/navigation_langgraph_memory/README.md
@@ -7,23 +7,30 @@ generate map links, and recall long-term user preferences.
 ## Architecture
 
 ```
-[User input] -> [LangGraph agent (LLM + tools)]
-                    |                 |
-              tool_calls?          no tool_calls
-                    v                 v
-              [ToolNode] <--- loop --  [reply]
-                    |
-     geocode_address / search_poi / plan_route / generate_map_link / recall_memory
-                    |
-         [AMap API] / [AgentArts Memory search]
+[User input] -> [Auto-Recall] -> [LangGraph agent (LLM + tools)]
+                     |               |                 |
+                Store.search    tool_calls?          no tool_calls
+                     |               v                 v
+              [AgentArts        [ToolNode] <--- loop --  [reply]
+               Memory Store]         |
+                              geocode_address / search_poi / plan_route
+                              / generate_map_link / recall_memory
+                                      |
+                          [AMap API] / [AgentArts Memory search]
 ```
 
 - **Short-term memory**: `AgentArtsMemorySessionSaver` checkpointer
   persists conversation state to AgentArts Memory. The backend
   auto-extracts memories using four builtin strategies (semantic,
   episodic, user_preference, summary).
-- **Long-term recall**: the `recall_memory` tool performs semantic
-  search over extracted memories when the LLM needs historical context.
+- **Long-term recall (hybrid)**: 
+  - *Auto-injection*: the `auto_recall` node searches `AgentArtsMemoryStore` (LangGraph Store)
+    before each LLM call, injecting top-K relevant memories into the system prompt
+    automatically. Zero tool-call latency for common preferences.
+  - *On-demand tool*: the `recall_memory` tool for deeper or more specific queries
+    beyond what was auto-injected.
+  - This hybrid pattern (Store auto-injection + on-demand tool) aligns with LangGraph's
+    recommended best practice for long-term memory integration.
 - **Navigation**: AMap (Gaode) Web Service API for POI search and
   route planning. Falls back to mock data when `AMAP_KEY` is not set.
 
@@ -113,9 +120,9 @@ agent: [calls recall_memory] You mentioned: you prefer highway routes.
 | `config.py` | Env vars, constants, shared config |
 | `setup_memory.py` | One-time: create memory space |
 | `amap_tools.py` | AMap API wrappers (geocode_address, search_poi, plan_route, generate_map_link) |
-| `memory_tools.py` | recall_memory tool (semantic search) |
+| `memory_tools.py` | recall_memory tool (on-demand deep semantic search) |
 | `session_manager.py` | Multi-session management (create/resume/list) |
-| `nav_agent.py` | LangGraph agent + interactive CLI/TUI |
+| `nav_agent.py` | LangGraph agent (auto_recall node + LLM + tools) + CLI/TUI |
 | `tui_app.py` | Textual TUI interface |
 | `tui_encoding.py` | Windows UTF-8 compatibility |
 | `cli_flags.py` | Shared DEBUG flag |
@@ -127,4 +134,7 @@ agent: [calls recall_memory] You mentioned: you prefer highway routes.
 - `VERIFY_SSL` defaults to `true`. Set to `false` in `.env` for internal network environments with self-signed certs.
 - Sessions are created on demand at agent startup; metadata is stored locally
   in `sessions.json` so previous conversations can be resumed.
-- Backend memory extraction runs on a ~30s idle timer; wait before testing `recall_memory`.
+- Backend memory extraction runs on a ~30s idle timer; wait before testing `recall_memory`
+  or expecting auto-injected memories to appear in new sessions.
+- Auto-recall can be disabled by setting `AUTO_RECALL_ENABLED = False` in `config.py`
+  (useful for comparison testing or debugging).

--- a/examples/navigation_langgraph_memory/README.md
+++ b/examples/navigation_langgraph_memory/README.md
@@ -1,0 +1,130 @@
+# Navigation Agent Demo
+
+A local interactive navigation assistant built with LangGraph and the
+AgentArts Memory SDK. The agent can search for places, plan routes,
+generate map links, and recall long-term user preferences.
+
+## Architecture
+
+```
+[User input] -> [LangGraph agent (LLM + tools)]
+                    |                 |
+              tool_calls?          no tool_calls
+                    v                 v
+              [ToolNode] <--- loop --  [reply]
+                    |
+     geocode_address / search_poi / plan_route / generate_map_link / recall_memory
+                    |
+         [AMap API] / [AgentArts Memory search]
+```
+
+- **Short-term memory**: `AgentArtsMemorySessionSaver` checkpointer
+  persists conversation state to AgentArts Memory. The backend
+  auto-extracts memories using four builtin strategies (semantic,
+  episodic, user_preference, summary).
+- **Long-term recall**: the `recall_memory` tool performs semantic
+  search over extracted memories when the LLM needs historical context.
+- **Navigation**: AMap (Gaode) Web Service API for POI search and
+  route planning. Falls back to mock data when `AMAP_KEY` is not set.
+
+## Prerequisites
+
+```bash
+# Install dependencies (langgraph + tui)
+uv sync --extra langgraph --extra tui
+# Or: pip install -r examples/navigation_langgraph_memory/requirements.txt
+
+# Copy the env template and fill in your credentials
+cp examples/navigation_langgraph_memory/.env.example examples/navigation_langgraph_memory/.env
+# Edit examples/navigation_langgraph_memory/.env with your API keys
+```
+
+## Quick Start
+
+### 1. Create a memory space (run once)
+
+```bash
+uv run python examples/navigation_langgraph_memory/setup_memory.py
+```
+
+This creates a memory space and automatically writes `AGENTARTS_MEMORY_SPACE_ID`
+and `HUAWEICLOUD_SDK_MEMORY_API_KEY` into `examples/navigation_langgraph_memory/.env`.
+
+### 2. Fill in LLM credentials
+
+Edit `examples/navigation_langgraph_memory/.env` and set your LLM provider keys:
+
+```
+OPENAI_API_KEY=sk-...
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL_NAME=gpt-4o-mini
+```
+
+### 3. (Optional) Set AMap key for real navigation data
+
+In `examples/navigation_langgraph_memory/.env`:
+
+```
+AMAP_KEY=your-amap-web-service-key
+```
+
+Without this key, the agent uses mock POI/route data so the graph
+logic can still be exercised.
+
+### 4. Start the agent
+
+```bash
+# TUI mode (default)
+uv run python examples/navigation_langgraph_memory/nav_agent.py
+
+# Classic CLI mode
+uv run python examples/navigation_langgraph_memory/nav_agent.py --cli
+
+# Debug mode (show SDK logs)
+uv run python examples/navigation_langgraph_memory/nav_agent.py --debug
+```
+
+## Example Session
+
+```
+you: 帮我找附近的加油站
+agent: [calls search_poi] Found 3 gas stations near you:
+  1. 中石化朝阳加油站 - 朝阳路88号
+  2. 中石油建国路加油站 - 建国路100号
+  3. 壳牌三环加油站 - 南三环西路6号
+  Which one would you like to navigate to?
+
+you: 帮我规划到第一个的驾车路线
+agent: [calls plan_route] Driving route to 中石化朝阳加油站:
+  Distance: 12.5km, Duration: ~28min
+  Nav link: https://uri.amap.com/navigation?to=...
+
+you: 我喜欢走高速
+agent: Got it - you prefer highway routes. I'll keep that in mind.
+
+you: 我之前说过什么偏好？
+agent: [calls recall_memory] You mentioned: you prefer highway routes.
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `config.py` | Env vars, constants, shared config |
+| `setup_memory.py` | One-time: create memory space |
+| `amap_tools.py` | AMap API wrappers (geocode_address, search_poi, plan_route, generate_map_link) |
+| `memory_tools.py` | recall_memory tool (semantic search) |
+| `session_manager.py` | Multi-session management (create/resume/list) |
+| `nav_agent.py` | LangGraph agent + interactive CLI/TUI |
+| `tui_app.py` | Textual TUI interface |
+| `tui_encoding.py` | Windows UTF-8 compatibility |
+| `cli_flags.py` | Shared DEBUG flag |
+| `.env.example` | Environment variable template |
+| `requirements.txt` | Dependencies for pip users |
+
+## Notes
+
+- `VERIFY_SSL` defaults to `true`. Set to `false` in `.env` for internal network environments with self-signed certs.
+- Sessions are created on demand at agent startup; metadata is stored locally
+  in `sessions.json` so previous conversations can be resumed.
+- Backend memory extraction runs on a ~30s idle timer; wait before testing `recall_memory`.

--- a/examples/navigation_langgraph_memory/README.md
+++ b/examples/navigation_langgraph_memory/README.md
@@ -26,7 +26,7 @@ generate map links, and recall long-term user preferences.
 - **Long-term recall (hybrid)**: 
   - *Auto-injection*: the `auto_recall` node searches `AgentArtsMemoryStore` (LangGraph Store)
     before each LLM call, injecting top-K relevant memories into the system prompt
-    automatically. Zero tool-call latency for common preferences.
+    automatically. No tool call needed for common preferences — saves an LLM round-trip (search itself still incurs network latency).
   - *On-demand tool*: the `recall_memory` tool for deeper or more specific queries
     beyond what was auto-injected.
   - This hybrid pattern (Store auto-injection + on-demand tool) aligns with LangGraph's
@@ -39,6 +39,7 @@ generate map links, and recall long-term user preferences.
 ```bash
 # Install dependencies (langgraph + tui)
 uv sync --extra langgraph --extra tui
+uv pip install langchain-openai   # demo-specific: ChatOpenAI LLM client
 # Or: pip install -r examples/navigation_langgraph_memory/requirements.txt
 
 # Copy the env template and fill in your credentials
@@ -84,10 +85,10 @@ logic can still be exercised.
 # TUI mode (default)
 uv run python examples/navigation_langgraph_memory/nav_agent.py
 
-# Classic CLI mode
+# Classic CLI mode (no SDK logs)
 uv run python examples/navigation_langgraph_memory/nav_agent.py --cli
 
-# Debug mode (show SDK logs)
+# Debug mode (CLI + SDK INFO logs)
 uv run python examples/navigation_langgraph_memory/nav_agent.py --debug
 ```
 
@@ -120,6 +121,8 @@ agent: [calls recall_memory] You mentioned: you prefer highway routes.
 | `config.py` | Env vars, constants, shared config |
 | `setup_memory.py` | One-time: create memory space |
 | `amap_tools.py` | AMap API wrappers (geocode_address, search_poi, plan_route, generate_map_link) |
+| `prompts.py` | Centralized system prompt definitions |
+| `message_utils.py` | Shared message content extraction and history helpers |
 | `memory_tools.py` | recall_memory tool (on-demand deep semantic search) |
 | `session_manager.py` | Multi-session management (create/resume/list) |
 | `nav_agent.py` | LangGraph agent (auto_recall node + LLM + tools) + CLI/TUI |

--- a/examples/navigation_langgraph_memory/README_CN.md
+++ b/examples/navigation_langgraph_memory/README_CN.md
@@ -1,0 +1,120 @@
+# 导航 Agent 示例
+
+基于 LangGraph 和 AgentArts Memory SDK 构建的本地交互式导航助手。该 Agent 能够搜索地点、规划路线、生成地图链接，并召回用户的长期偏好。
+
+## 架构
+
+```
+[用户输入] -> [LangGraph agent (LLM + tools)]
+                    |                 |
+              tool_calls?          no tool_calls
+                    v                 v
+              [ToolNode] <--- loop --  [回复]
+                    |
+     geocode_address / search_poi / plan_route / generate_map_link / recall_memory
+                    |
+         [高德地图 API] / [AgentArts Memory 搜索]
+```
+
+- **短期记忆**：`AgentArtsMemorySessionSaver` 检查点将对话状态持久化到 AgentArts Memory。后端使用四种内置策略（语义、情景、用户偏好、摘要）自动提取记忆。
+- **长期召回**：`recall_memory` 工具在 LLM 需要历史上下文时，对提取的记忆执行语义搜索。
+- **导航**：使用高德地图 Web Service API 进行 POI 搜索和路线规划。未设置 `AMAP_KEY` 时回退到模拟数据。
+
+## 前置条件
+
+```bash
+# 安装依赖（langgraph + tui）
+uv sync --extra langgraph --extra tui
+# 或：pip install -r examples/navigation_langgraph_memory/requirements.txt
+
+# 复制环境变量模板并填写凭据
+cp examples/navigation_langgraph_memory/.env.example examples/navigation_langgraph_memory/.env
+# 编辑 examples/navigation_langgraph_memory/.env 填入 API 密钥
+```
+
+## 快速开始
+
+### 1. 创建记忆空间（运行一次）
+
+```bash
+uv run python examples/navigation_langgraph_memory/setup_memory.py
+```
+
+这会创建记忆空间，并自动将 `AGENTARTS_MEMORY_SPACE_ID` 和 `HUAWEICLOUD_SDK_MEMORY_API_KEY` 写入 `examples/navigation_langgraph_memory/.env`。
+
+### 2. 填写 LLM 凭据
+
+编辑 `examples/navigation_langgraph_memory/.env` 并设置 LLM 提供商密钥：
+
+```
+OPENAI_API_KEY=sk-...
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL_NAME=gpt-4o-mini
+```
+
+### 3. （可选）设置高德地图密钥以获取真实导航数据
+
+在 `examples/navigation_langgraph_memory/.env` 中：
+
+```
+AMAP_KEY=your-amap-web-service-key
+```
+
+未设置此密钥时，Agent 使用模拟 POI/路线数据，仍可测试图逻辑。
+
+### 4. 启动 Agent
+
+```bash
+# TUI 模式（默认）
+uv run python examples/navigation_langgraph_memory/nav_agent.py
+
+# 经典 CLI 模式
+uv run python examples/navigation_langgraph_memory/nav_agent.py --cli
+
+# 调试模式（显示 SDK 日志）
+uv run python examples/navigation_langgraph_memory/nav_agent.py --debug
+```
+
+## 示例会话
+
+```
+you: 帮我找附近的加油站
+agent: [调用 search_poi] 找到附近 3 个加油站：
+  1. 中石化朝阳加油站 - 朝阳路88号
+  2. 中石油建国路加油站 - 建国路100号
+  3. 壳牌三环加油站 - 南三环西路6号
+  您想导航到哪个？
+
+you: 帮我规划到第一个的驾车路线
+agent: [调用 plan_route] 到 中石化朝阳加油站 的驾车路线：
+  距离：12.5km，预计时间：~28分钟
+  导航链接：https://uri.amap.com/navigation?to=...
+
+you: 我喜欢走高速
+agent: 好的，您偏好高速路线。我会记住这个偏好。
+
+you: 我之前说过什么偏好？
+agent: [调用 recall_memory] 您提到过：您偏好高速路线。
+```
+
+## 文件说明
+
+| 文件 | 用途 |
+|------|------|
+| `config.py` | 环境变量、常量、共享配置 |
+| `setup_memory.py` | 一次性：创建记忆空间 |
+| `amap_tools.py` | 高德地图 API 封装（geocode_address、search_poi、plan_route、generate_map_link） |
+| `memory_tools.py` | recall_memory 工具（语义搜索） |
+| `session_manager.py` | 多会话管理（创建/恢复/列表） |
+| `nav_agent.py` | LangGraph agent + 交互式 CLI/TUI |
+| `tui_app.py` | Textual TUI 界面 |
+| `tui_encoding.py` | Windows UTF-8 兼容性 |
+| `cli_flags.py` | 共享 DEBUG 标志 |
+| `.env.example` | 环境变量模板 |
+| `requirements.txt` | pip 用户依赖 |
+
+## 注意事项
+
+- `VERIFY_SSL` 默认为 `true`。对于使用自签名证书的内网环境，在 `.env` 中设置为 `false`。
+- 会话在 Agent 启动时按需创建；元数据存储在本地 `sessions.json` 中，以便恢复之前的对话。
+- 后端记忆提取在约 30 秒空闲计时器后运行；测试 `recall_memory` 前请等待。

--- a/examples/navigation_langgraph_memory/README_CN.md
+++ b/examples/navigation_langgraph_memory/README_CN.md
@@ -19,7 +19,7 @@
 
 - **短期记忆**：`AgentArtsMemorySessionSaver` 检查点将对话状态持久化到 AgentArts Memory。后端使用四种内置策略（语义、情景、用户偏好、摘要）自动提取记忆。
 - **长期召回（混合模式）**：
-  - *自动注入*：`auto_recall` 节点在每次 LLM 调用前搜索 `AgentArtsMemoryStore`（LangGraph Store），将最相关的 Top-K 记忆自动注入系统提示词。常见偏好无需工具调用，零延迟。
+  - *自动注入*：`auto_recall` 节点在每次 LLM 调用前搜索 `AgentArtsMemoryStore`（LangGraph Store），将最相关的 Top-K 记忆自动注入系统提示词。常见偏好无需工具调用，省去一次 LLM 调用轮次（搜索本身仍有网络延迟）。
   - *按需工具*：`recall_memory` 工具用于超出自动注入范围的更深层或更具体的查询。
   - 此混合模式（Store 自动注入 + 按需工具）符合 LangGraph 推荐的长期记忆集成最佳实践。
 - **导航**：使用高德地图 Web Service API 进行 POI 搜索和路线规划。未设置 `AMAP_KEY` 时回退到模拟数据。
@@ -29,6 +29,7 @@
 ```bash
 # 安装依赖（langgraph + tui）
 uv sync --extra langgraph --extra tui
+uv pip install langchain-openai   # demo 专用：ChatOpenAI LLM 客户端
 # 或：pip install -r examples/navigation_langgraph_memory/requirements.txt
 
 # 复制环境变量模板并填写凭据
@@ -72,10 +73,10 @@ AMAP_KEY=your-amap-web-service-key
 # TUI 模式（默认）
 uv run python examples/navigation_langgraph_memory/nav_agent.py
 
-# 经典 CLI 模式
+# 经典 CLI 模式（无 SDK 日志）
 uv run python examples/navigation_langgraph_memory/nav_agent.py --cli
 
-# 调试模式（显示 SDK 日志）
+# 调试模式（CLI + SDK 日志）
 uv run python examples/navigation_langgraph_memory/nav_agent.py --debug
 ```
 
@@ -108,6 +109,8 @@ agent: [调用 recall_memory] 您提到过：您偏好高速路线。
 | `config.py` | 环境变量、常量、共享配置 |
 | `setup_memory.py` | 一次性：创建记忆空间 |
 | `amap_tools.py` | 高德地图 API 封装（geocode_address、search_poi、plan_route、generate_map_link） |
+| `prompts.py` | 系统提示词集中管理 |
+| `message_utils.py` | 消息内容提取和历史查询共享逻辑 |
 | `memory_tools.py` | recall_memory 工具（按需深度语义搜索） |
 | `session_manager.py` | 多会话管理（创建/恢复/列表） |
 | `nav_agent.py` | LangGraph agent（auto_recall 节点 + LLM + 工具）+ CLI/TUI |

--- a/examples/navigation_langgraph_memory/README_CN.md
+++ b/examples/navigation_langgraph_memory/README_CN.md
@@ -5,19 +5,23 @@
 ## 架构
 
 ```
-[用户输入] -> [LangGraph agent (LLM + tools)]
-                    |                 |
-              tool_calls?          no tool_calls
-                    v                 v
-              [ToolNode] <--- loop --  [回复]
-                    |
-     geocode_address / search_poi / plan_route / generate_map_link / recall_memory
-                    |
-         [高德地图 API] / [AgentArts Memory 搜索]
+[用户输入] -> [Auto-Recall] -> [LangGraph agent (LLM + tools)]
+                     |               |                 |
+                Store.search    tool_calls?          no tool_calls
+                     |               v                 v
+              [AgentArts        [ToolNode] <--- loop --  [回复]
+               Memory Store]         |
+                              geocode_address / search_poi / plan_route
+                              / generate_map_link / recall_memory
+                                      |
+                          [高德地图 API] / [AgentArts Memory 搜索]
 ```
 
 - **短期记忆**：`AgentArtsMemorySessionSaver` 检查点将对话状态持久化到 AgentArts Memory。后端使用四种内置策略（语义、情景、用户偏好、摘要）自动提取记忆。
-- **长期召回**：`recall_memory` 工具在 LLM 需要历史上下文时，对提取的记忆执行语义搜索。
+- **长期召回（混合模式）**：
+  - *自动注入*：`auto_recall` 节点在每次 LLM 调用前搜索 `AgentArtsMemoryStore`（LangGraph Store），将最相关的 Top-K 记忆自动注入系统提示词。常见偏好无需工具调用，零延迟。
+  - *按需工具*：`recall_memory` 工具用于超出自动注入范围的更深层或更具体的查询。
+  - 此混合模式（Store 自动注入 + 按需工具）符合 LangGraph 推荐的长期记忆集成最佳实践。
 - **导航**：使用高德地图 Web Service API 进行 POI 搜索和路线规划。未设置 `AMAP_KEY` 时回退到模拟数据。
 
 ## 前置条件
@@ -104,9 +108,9 @@ agent: [调用 recall_memory] 您提到过：您偏好高速路线。
 | `config.py` | 环境变量、常量、共享配置 |
 | `setup_memory.py` | 一次性：创建记忆空间 |
 | `amap_tools.py` | 高德地图 API 封装（geocode_address、search_poi、plan_route、generate_map_link） |
-| `memory_tools.py` | recall_memory 工具（语义搜索） |
+| `memory_tools.py` | recall_memory 工具（按需深度语义搜索） |
 | `session_manager.py` | 多会话管理（创建/恢复/列表） |
-| `nav_agent.py` | LangGraph agent + 交互式 CLI/TUI |
+| `nav_agent.py` | LangGraph agent（auto_recall 节点 + LLM + 工具）+ CLI/TUI |
 | `tui_app.py` | Textual TUI 界面 |
 | `tui_encoding.py` | Windows UTF-8 兼容性 |
 | `cli_flags.py` | 共享 DEBUG 标志 |
@@ -117,4 +121,5 @@ agent: [调用 recall_memory] 您提到过：您偏好高速路线。
 
 - `VERIFY_SSL` 默认为 `true`。对于使用自签名证书的内网环境，在 `.env` 中设置为 `false`。
 - 会话在 Agent 启动时按需创建；元数据存储在本地 `sessions.json` 中，以便恢复之前的对话。
-- 后端记忆提取在约 30 秒空闲计时器后运行；测试 `recall_memory` 前请等待。
+- 后端记忆提取在约 30 秒空闲计时器后运行；测试 `recall_memory` 或期望新会话中出现自动注入的记忆前，请先等待。
+- 可通过在 `config.py` 中设置 `AUTO_RECALL_ENABLED = False` 来禁用自动召回（用于对比测试或调试）。

--- a/examples/navigation_langgraph_memory/amap_tools.py
+++ b/examples/navigation_langgraph_memory/amap_tools.py
@@ -1,0 +1,382 @@
+"""
+Navigation Agent Demo - AMap (Gaode Maps) Tools
+
+Python port of the original amap-lbs-skill/index.js. Exposes four
+LangChain tools: geocode_address, search_poi, plan_route,
+generate_map_link.
+
+When AMAP_KEY is not set, tools return mock data so the agent graph
+can be exercised end-to-end without a real AMap key.
+"""
+
+import json
+import urllib.parse
+
+import requests
+from langchain_core.tools import tool
+
+import cli_flags  # noqa: F401
+import config  # noqa: F401  (sets env vars as side effect)
+from config import AMAP_BASE, AMAP_KEY
+
+_mock_warned = False
+
+
+def _warn_mock():
+    """Print mock data warning once in debug mode."""
+    global _mock_warned
+    if not _mock_warned and cli_flags.DEBUG:
+        print("[MOCK] AMAP_KEY not set - using simulated data.")
+        print("[MOCK] Set AMAP_KEY env var to enable real AMap API calls.")
+    _mock_warned = True
+
+
+def _safe_get(url, params, timeout=10):
+    """Wrapper around requests.get with error handling.
+
+    Returns (data_dict, None) on success, (None, error_str) on failure.
+    """
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+        return resp.json(), None
+    except requests.exceptions.Timeout:
+        return None, f"Request timed out after {timeout}s"
+    except requests.exceptions.ConnectionError as e:
+        return None, f"Connection error: {e}"
+    except requests.exceptions.RequestException as e:
+        return None, f"Request failed: {e}"
+    except (ValueError, KeyError) as e:
+        return None, f"Response parse error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Mock data
+# ---------------------------------------------------------------------------
+
+_MOCK_POIS = {
+    "加油站": [
+        {"name": "中石化朝阳加油站", "address": "北京市朝阳区朝阳路88号",
+         "location": "116.481181,39.990021", "tel": "010-12345678",
+         "type": "加油站", "distance": ""},
+        {"name": "中石油建国路加油站", "address": "北京市朝阳区建国路100号",
+         "location": "116.461810,39.921000", "tel": "010-87654321",
+         "type": "加油站", "distance": ""},
+        {"name": "壳牌三环加油站", "address": "北京市丰台区南三环西路6号",
+         "location": "116.378432,39.865000", "tel": "010-11112222",
+         "type": "加油站", "distance": ""},
+    ],
+    "餐厅": [
+        {"name": "全聚德烤鸭店(前门店)", "address": "北京市东城区前门大街30号",
+         "location": "116.397428,39.898556", "tel": "010-65112233",
+         "type": "中餐厅", "distance": ""},
+        {"name": "海底捞火锅(朝阳大悦城店)", "address": "北京市朝阳区朝阳北路101号",
+         "location": "116.510181,39.930230", "tel": "010-85556666",
+         "type": "火锅店", "distance": ""},
+    ],
+    "停车场": [
+        {"name": "国贸地下停车场", "address": "北京市朝阳区建国门外大街1号",
+         "location": "116.461810,39.908000", "tel": "",
+         "type": "停车场", "distance": ""},
+        {"name": "三里屯SOHO停车场", "address": "北京市朝阳区三里屯路19号",
+         "location": "116.454350,39.935580", "tel": "",
+         "type": "停车场", "distance": ""},
+    ],
+}
+
+_MOCK_DEFAULT = [
+    {"name": "示例地点A", "address": "示例地址1", "location": "116.480000,39.990000",
+     "tel": "", "type": "", "distance": ""},
+    {"name": "示例地点B", "address": "示例地址2", "location": "116.460000,39.920000",
+     "tel": "", "type": "", "distance": ""},
+]
+
+_MOCK_GEOCODE = {
+    "formatted_address": "北京市海淀区中关村",
+    "location": "116.310003,39.991957",
+}
+
+
+def _mock_pois(keywords, city):
+    """Return mock POI data for given keywords, optionally prefixed with city."""
+    _warn_mock()
+    pois = _MOCK_POIS.get(keywords, _MOCK_DEFAULT)
+    if city:
+        pois = [dict(p, address=f"{city}{p['address']}") for p in pois]
+    return json.dumps(pois, ensure_ascii=False)
+
+
+def _mock_route(origin, destination, mode):
+    """Return mock route data with navigation link for given origin/destination/mode."""
+    _warn_mock()
+    mode_label = {"driving": "驾车", "walking": "步行", "riding": "骑行",
+                  "transit": "公交"}.get(mode, mode)
+    # Map internal mode names to AMap URI API mode values
+    uri_mode = {"driving": "car", "walking": "walk",
+                "riding": "ride", "transit": "bus"}.get(mode, "car")
+    nav_link = (
+        f"https://uri.amap.com/navigation?from={origin},start"
+        f"&to={destination},end&mode={uri_mode}&policy=1&src=mypage&callnative=0"
+    )
+    return json.dumps({
+        "mode": mode_label,
+        "distance_m": "12500" if mode == "driving" else "3200",
+        "duration_s": "1680" if mode == "driving" else "2700",
+        "tolls": "0" if mode == "driving" else "",
+        "traffic_lights": "8" if mode == "driving" else "",
+        "cost": "",
+        "nav_link": nav_link,
+        "note": "Mock route - set AMAP_KEY for real data.",
+    }, ensure_ascii=False)
+
+
+def _mock_geocode(address):
+    """Return mock geocode result for given address."""
+    _warn_mock()
+    result = dict(_MOCK_GEOCODE)
+    result["formatted_address"] = f"{address}（模拟地址）"
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@tool
+def geocode_address(address: str, city: str = "") -> str:
+    """Convert a place name or address to coordinates.
+
+    Use this when the user gives a place name (e.g. "中关村", "南京站")
+    instead of coordinates, before calling plan_route or search_poi
+    with location.
+
+    Args:
+        address: Place name or address, e.g. "中关村", "南京南站"
+        city: City to narrow search, e.g. "北京". Optional.
+
+    Returns:
+        JSON with formatted_address and location ("lng,lat"),
+        or error message.
+    """
+    if not AMAP_KEY:
+        return _mock_geocode(address)
+
+    params = {"key": AMAP_KEY, "address": address}
+    if city:
+        params["city"] = city
+
+    data, err = _safe_get(f"{AMAP_BASE}/v3/geocode/geo", params)
+    if err:
+        return f"Geocode failed: {err}"
+    if data.get("status") != "1":
+        return f"Geocode failed: {data.get('info', 'unknown error')}"
+
+    geocodes = data.get("geocodes", [])
+    if not geocodes:
+        return f"No coordinates found for '{address}'"
+
+    g = geocodes[0]
+    return json.dumps({
+        "formatted_address": g.get("formatted_address", ""),
+        "location": g.get("location", ""),
+    }, ensure_ascii=False)
+
+
+@tool
+def search_poi(keywords: str, city: str = "", location: str = "",
+               radius: int = 3000, types: str = "") -> str:
+    """Search for points of interest (POI). Supports keyword search and
+    nearby search around a center point.
+
+    Args:
+        keywords: Search terms, e.g. "加油站" (gas station), "餐厅" (restaurant)
+        city: City name to narrow the search, e.g. "北京". Optional.
+        location: Center coordinates "lng,lat" for nearby search. When
+            provided, searches within radius of this point. Optional.
+        radius: Search radius in meters when location is given. Default 3000.
+        types: POI type code filter, e.g. "010000" for gas station. Optional.
+
+    Returns:
+        JSON list of POIs, each with name, address, location, tel, type,
+        and distance (from center, if applicable).
+    """
+    if not AMAP_KEY:
+        return _mock_pois(keywords, city)
+
+    params = {
+        "key": AMAP_KEY,
+        "keywords": keywords,
+        "region": city,
+        "city_limit": "true" if city else "false",
+        "page_size": 5,
+        "page": 1,
+    }
+    if location:
+        params["location"] = location
+        params["radius"] = radius
+        params["sortrule"] = "distance"
+    if types:
+        params["types"] = types
+
+    data, err = _safe_get(f"{AMAP_BASE}/v5/place/text", params)
+    if err:
+        return f"Search failed: {err}"
+    if data.get("status") != "1":
+        return f"Search failed: {data.get('info', 'unknown error')}"
+
+    pois = data.get("pois", [])[:5]
+    if not pois:
+        return f"No results found for '{keywords}' in '{city or 'all'}'"
+
+    results = [
+        {
+            "name": p.get("name", ""),
+            "address": p.get("address", ""),
+            "location": p.get("location", ""),
+            "tel": p.get("tel", ""),
+            "type": p.get("type", ""),
+            "distance": p.get("distance", ""),
+        }
+        for p in pois
+    ]
+    return json.dumps(results, ensure_ascii=False)
+
+
+@tool
+def plan_route(origin: str, destination: str, mode: str = "driving",
+               waypoints: str = "", city: str = "") -> str:
+    """Plan a route from origin to destination.
+
+    Args:
+        origin: Start coordinates as "longitude,latitude"
+            e.g. "116.481181,39.990021"
+        destination: End coordinates as "longitude,latitude"
+        mode: Travel mode - one of: driving, walking, riding, transit.
+            Default: driving.
+        waypoints: Intermediate stops for driving only, format
+            "lng,lat;lng,lat" (up to 16 stops, semicolon-separated). Optional.
+        city: City name, required for transit mode. Optional for others.
+
+    Returns:
+        JSON with distance, duration, navigation link, and mode-specific
+        details (tolls/traffic_lights for driving, cost for transit).
+    """
+    if not AMAP_KEY:
+        return _mock_route(origin, destination, mode)
+
+    if mode == "walking":
+        url = f"{AMAP_BASE}/v3/direction/walking"
+        params = {"key": AMAP_KEY, "origin": origin, "destination": destination}
+    elif mode == "driving":
+        url = f"{AMAP_BASE}/v3/direction/driving"
+        params = {
+            "key": AMAP_KEY, "origin": origin, "destination": destination,
+            "strategy": 10, "extensions": "base",
+        }
+        if waypoints:
+            params["waypoints"] = waypoints
+    elif mode == "riding":
+        url = f"{AMAP_BASE}/v4/direction/bicycling"
+        params = {"key": AMAP_KEY, "origin": origin, "destination": destination}
+    elif mode == "transit":
+        url = f"{AMAP_BASE}/v3/direction/transit/integrated"
+        if not city:
+            return "Transit mode requires 'city' parameter."
+        params = {
+            "key": AMAP_KEY, "origin": origin, "destination": destination,
+            "city": city, "strategy": 0,
+        }
+    else:
+        return f"Invalid mode '{mode}'. Use: driving, walking, riding, transit"
+
+    data, err = _safe_get(url, params, timeout=15)
+    if err:
+        return f"Route planning failed: {err}"
+
+    # riding uses errcode, others use status
+    ok = data.get("status") == "1" or data.get("errcode") == 0
+    if not ok:
+        msg = data.get("info") or data.get("errmsg", "unknown")
+        return f"Route planning failed: {msg}"
+
+    # transit uses route.transits, others use route.paths
+    route_root = data.get("route", {})
+    if mode == "transit":
+        transits = route_root.get("transits", [])
+        route = transits[0] if transits else {}
+        distance = route.get("distance", "N/A")
+        duration = route.get("duration", "N/A")
+        cost_info = route.get("cost", {})
+        if isinstance(cost_info, dict):
+            duration = cost_info.get("duration", duration)
+            cost = cost_info.get("transit_fee", "")
+        else:
+            cost = str(cost_info) if cost_info else ""
+        tolls = ""
+        traffic_lights = ""
+    else:
+        route = route_root.get("paths", [{}])[0]
+        distance = route.get("distance", "N/A")
+        duration = route.get("duration", "N/A")
+        tolls = ""
+        traffic_lights = ""
+        cost = ""
+        if mode == "driving":
+            tolls = route.get("tolls", "")
+            traffic_lights = route.get("traffic_lights", "")
+
+    # Map internal mode names to AMap URI API mode values
+    mode_map = {
+        "driving": "car",
+        "walking": "walk",
+        "riding": "ride",
+        "transit": "bus",
+    }
+    uri_mode = mode_map.get(mode, "car")
+    nav_link = (
+        f"https://uri.amap.com/navigation?from={origin},start"
+        f"&to={destination},end&mode={uri_mode}&policy=1&src=mypage&callnative=0"
+    )
+    if waypoints and mode == "driving":
+        nav_link += f"&via={waypoints},midway"
+    return json.dumps({
+        "mode": mode,
+        "distance_m": distance,
+        "duration_s": duration,
+        "tolls": tolls,
+        "traffic_lights": traffic_lights,
+        "cost": cost,
+        "nav_link": nav_link,
+    }, ensure_ascii=False)
+
+
+@tool
+def generate_map_link(pois: str) -> str:
+    """Generate a map visualization link showing one or more locations.
+
+    Args:
+        pois: JSON string of a list, each item like
+            {"name": "...", "lnglat": [longitude, latitude]}
+
+    Returns:
+        A URL that opens an AMap visualization page with markers.
+    """
+    try:
+        poi_list = json.loads(pois) if isinstance(pois, str) else pois
+    except (json.JSONDecodeError, TypeError):
+        return "Invalid pois format. Provide JSON list of {name, lnglat}."
+
+    map_data = []
+    for p in poi_list:
+        lnglat = p.get("lnglat") or p.get("location")
+        if isinstance(lnglat, str):
+            parts = lnglat.split(",")
+            lnglat = [float(parts[0]), float(parts[1])]
+        map_data.append({
+            "type": "poi",
+            "lnglat": lnglat,
+            "text": p.get("name", ""),
+            "remark": p.get("address", ""),
+        })
+
+    data_str = urllib.parse.quote(json.dumps(map_data, ensure_ascii=False))
+    return f"https://a.amap.com/jsapi_demo_show/static/openclaw/travel_plan.html?data={data_str}"

--- a/examples/navigation_langgraph_memory/cli_flags.py
+++ b/examples/navigation_langgraph_memory/cli_flags.py
@@ -1,0 +1,7 @@
+"""Runtime CLI flags shared across the nav agent demo.
+
+Set once by nav_agent.main() based on --debug argv parsing.
+Defaults to False (clean mode).
+"""
+
+DEBUG: bool = False

--- a/examples/navigation_langgraph_memory/config.py
+++ b/examples/navigation_langgraph_memory/config.py
@@ -27,7 +27,7 @@ if _env_file.exists():
 # ---------------------------------------------------------------------------
 AGENTARTS_CONTROL_ENDPOINT = os.getenv(
     "AGENTARTS_CONTROL_ENDPOINT",
-    "https://agentarts.myhuaweicloud.com",
+    "https://agentarts.cn-southwest-2.myhuaweicloud.com",
 )
 AGENTARTS_MEMORY_DATA_ENDPOINT = os.getenv("AGENTARTS_MEMORY_DATA_ENDPOINT")
 
@@ -64,3 +64,11 @@ ACTOR_ID = "user-nav-demo"
 ASSISTANT_ID = "nav-agent-demo"
 SPACE_NAME = "memory-nav-agent-demo"
 SPACE_DESCRIPTION = "Navigation agent demo memory space"
+
+# ---------------------------------------------------------------------------
+# Auto-recall configuration (hybrid memory recall)
+# The auto_recall node searches the Store for relevant long-term memories
+# before each LLM call and injects them into the system prompt.
+# ---------------------------------------------------------------------------
+AUTO_RECALL_TOP_K = 3       # max memories to auto-inject per turn
+AUTO_RECALL_ENABLED = True  # toggle auto-injection (for comparison/testing)

--- a/examples/navigation_langgraph_memory/config.py
+++ b/examples/navigation_langgraph_memory/config.py
@@ -1,0 +1,66 @@
+"""
+Navigation Agent Demo - Shared Configuration
+
+Loads environment variables from .env file (if present) and reads
+runtime configuration (memory space ID, LLM credentials, AMap key).
+
+Sessions are created on demand by session_manager.py — no
+SESSION_ID is needed in config. Each conversation gets its own
+AgentArts Memory session at startup.
+
+Usage:
+    import config  # noqa: F401  (side-effect: loads .env)
+    from config import SPACE_ID, API_KEY, ...
+"""
+
+import os
+from pathlib import Path
+
+# Load .env file from the demo directory
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    from dotenv import load_dotenv
+    load_dotenv(_env_file)
+
+# ---------------------------------------------------------------------------
+# AgentArts Memory SDK endpoints
+# ---------------------------------------------------------------------------
+AGENTARTS_CONTROL_ENDPOINT = os.getenv(
+    "AGENTARTS_CONTROL_ENDPOINT",
+    "https://agentarts.myhuaweicloud.com",
+)
+AGENTARTS_MEMORY_DATA_ENDPOINT = os.getenv("AGENTARTS_MEMORY_DATA_ENDPOINT")
+
+# ---------------------------------------------------------------------------
+# SSL verification
+# ---------------------------------------------------------------------------
+VERIFY_SSL = os.getenv("VERIFY_SSL", "true").lower() == "true"
+
+# ---------------------------------------------------------------------------
+# Memory Space ID - set after running setup_memory.py (once).
+# Sessions are created on demand by session_manager.py.
+# ---------------------------------------------------------------------------
+SPACE_ID = os.getenv("AGENTARTS_MEMORY_SPACE_ID")
+API_KEY = os.getenv("HUAWEICLOUD_SDK_MEMORY_API_KEY")
+
+# ---------------------------------------------------------------------------
+# LLM configuration (OpenAI-compatible endpoint)
+# ---------------------------------------------------------------------------
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")
+OPENAI_MODEL_NAME = os.getenv("OPENAI_MODEL_NAME", "deepseek-v3.2")
+
+# ---------------------------------------------------------------------------
+# AMap (Gaode Maps) Web Service Key
+# ---------------------------------------------------------------------------
+AMAP_KEY = os.getenv("AMAP_KEY") or os.getenv("AMAP_WEBSERVICE_KEY")
+AMAP_BASE = "https://restapi.amap.com"
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+BUILTIN_STRATEGIES = ["semantic", "episodic", "user_preference", "summary"]
+ACTOR_ID = "user-nav-demo"
+ASSISTANT_ID = "nav-agent-demo"
+SPACE_NAME = "memory-nav-agent-demo"
+SPACE_DESCRIPTION = "Navigation agent demo memory space"

--- a/examples/navigation_langgraph_memory/memory_tools.py
+++ b/examples/navigation_langgraph_memory/memory_tools.py
@@ -1,0 +1,88 @@
+"""
+Navigation Agent Demo - Memory Recall Tool
+
+Exposes a single LangChain tool, recall_memory, that performs
+semantic search over the AgentArts Memory service to retrieve
+long-term memories (user preferences, historical facts, etc.).
+
+No save_memory tool is needed: the AgentArtsMemorySessionSaver
+checkpointer persists all conversation messages, and the backend's
+builtin strategies auto-extract memories (semantic, episodic,
+user_preference, summary).
+"""
+
+from langchain_core.tools import tool
+
+import config  # noqa: F401  (sets env vars as side effect)
+from agentarts.sdk import MemoryClient
+from agentarts.sdk.memory import MemorySearchFilter
+from config import API_KEY, SPACE_ID, VERIFY_SSL
+
+# Current session ID — set by nav_agent.py at startup via set_current_session().
+# NOTE: Currently unused by recall_memory() by design: long-term memories
+# are cross-session (see comment in recall_memory). Reserved for potential
+# future session-scoped queries.
+_current_session_id = None
+
+
+def set_current_session(session_id: str):
+    """Set the active session ID for recall_memory searches.
+
+    Called by nav_agent.py when a session is selected or created.
+    """
+    global _current_session_id
+    _current_session_id = session_id
+
+
+@tool
+def recall_memory(query: str) -> str:
+    """Retrieve relevant long-term memories via semantic search.
+
+    Call this when you need to recall the user's preferences, past
+    destinations, or historical interaction context. Do NOT call this
+    every turn - only when the user references preferences or history.
+
+    Args:
+        query: Natural language description of what to recall,
+            e.g. "user travel preferences" or "previous destinations"
+
+    Returns:
+        Bullet list of matching memories, or a "no memories" message.
+    """
+    if not SPACE_ID or not API_KEY:
+        return "Memory service not configured (SPACE_ID/API_KEY missing)."
+
+    client = MemoryClient(api_key=API_KEY, verify_ssl=VERIFY_SSL)
+    try:
+        # NOTE: Do NOT filter by session_id here. Long-term memories
+        # (user preferences, semantic facts) are extracted across ALL
+        # sessions and should be recallable from any conversation.
+        # Filtering by session_id would scope the search to only memories
+        # extracted from the current session, making cross-conversation
+        # recall impossible.
+        search_filter = MemorySearchFilter(
+            query=query,
+            top_k=5,
+        )
+        results = client.search_memories(space_id=SPACE_ID, filters=search_filter)
+
+        items = getattr(results, "results", None) or getattr(results, "items", None) or []
+        if not items:
+            return "No relevant memories found."
+
+        memories = []
+        for r in items:
+            record = r.get("record", r) if isinstance(r, dict) else {}
+            content = record.get("content", "")
+            strategy = record.get("strategy_type", "")
+            if content:
+                tag = f"[{strategy}] " if strategy else ""
+                memories.append(f"- {tag}{content}")
+
+        if not memories:
+            return "No relevant memories found."
+        return "\n".join(memories)
+    except Exception as e:
+        return f"Memory recall failed: {e}"
+    finally:
+        client.close()

--- a/examples/navigation_langgraph_memory/memory_tools.py
+++ b/examples/navigation_langgraph_memory/memory_tools.py
@@ -42,12 +42,12 @@ def set_current_session(session_id: str):
 
 @tool
 def recall_memory(query: str) -> str:
-    """Deep recall of specific long-term memories via semantic search.
+    """Search long-term memories with a targeted query.
 
-    Relevant memories are already auto-injected each turn via the Store
-    (see [Memory Context] in the system prompt). Only call this tool when
-    you need MORE DETAIL than what was auto-injected, or when searching for
-    a specific past event or preference.
+    The [Memory Context] in the system prompt is a lightweight auto-injected
+    preview (top 3). This tool returns more results (top 5) with a specific
+    query. Call it when the preview doesn't contain what the user is asking
+    about, or when the user references past preferences or prior conversations.
 
     Args:
         query: Natural language description of what to recall,

--- a/examples/navigation_langgraph_memory/memory_tools.py
+++ b/examples/navigation_langgraph_memory/memory_tools.py
@@ -5,6 +5,12 @@ Exposes a single LangChain tool, recall_memory, that performs
 semantic search over the AgentArts Memory service to retrieve
 long-term memories (user preferences, historical facts, etc.).
 
+This is the ON-DEMAND component of the hybrid recall architecture.
+The AUTO-INJECTION component is the auto_recall node in nav_agent.py,
+which searches AgentArtsMemoryStore before each LLM call and injects
+relevant memories into the system prompt. recall_memory is for deeper
+or more specific queries beyond the auto-injected context.
+
 No save_memory tool is needed: the AgentArtsMemorySessionSaver
 checkpointer persists all conversation messages, and the backend's
 builtin strategies auto-extract memories (semantic, episodic,
@@ -36,11 +42,12 @@ def set_current_session(session_id: str):
 
 @tool
 def recall_memory(query: str) -> str:
-    """Retrieve relevant long-term memories via semantic search.
+    """Deep recall of specific long-term memories via semantic search.
 
-    Call this when you need to recall the user's preferences, past
-    destinations, or historical interaction context. Do NOT call this
-    every turn - only when the user references preferences or history.
+    Relevant memories are already auto-injected each turn via the Store
+    (see [Memory Context] in the system prompt). Only call this tool when
+    you need MORE DETAIL than what was auto-injected, or when searching for
+    a specific past event or preference.
 
     Args:
         query: Natural language description of what to recall,

--- a/examples/navigation_langgraph_memory/message_utils.py
+++ b/examples/navigation_langgraph_memory/message_utils.py
@@ -1,0 +1,73 @@
+"""Navigation Agent Demo - Message Utilities
+
+Shared helpers for extracting message content and fetching session history.
+Used by both CLI (nav_agent.py) and TUI (tui_app.py) to avoid duplication.
+"""
+
+from typing import List, Tuple
+
+import config  # noqa: F401
+from config import API_KEY, SPACE_ID, VERIFY_SSL
+
+
+def extract_message_content(msg) -> str:
+    """Extract text content from a message (dict or MessageInfo object).
+
+    Handles SDK MessageInfo with 'parts' field: [{'type': 'text', 'text': '...'}].
+    Falls back to 'content' field or str(msg) for other formats.
+    """
+    if isinstance(msg, dict):
+        parts = msg.get("parts", [])
+    else:
+        parts = getattr(msg, "parts", [])
+
+    if parts:
+        texts = []
+        for p in parts:
+            if isinstance(p, dict):
+                if p.get("type") == "text":
+                    texts.append(p.get("text", ""))
+            elif getattr(p, "type", None) == "text":
+                texts.append(getattr(p, "text", ""))
+        return " ".join(texts)
+
+    # Fallback: try content field
+    if isinstance(msg, dict):
+        return msg.get("content", "")
+    else:
+        return getattr(msg, "content", "") or str(msg)
+
+
+def fetch_session_history(
+    session_id: str, k: int = 20
+) -> List[Tuple[str, str]]:
+    """Fetch recent messages from a session.
+
+    Returns list of (role, content) tuples for user/assistant messages only.
+    May raise exceptions on network/API failure — callers should handle them.
+    """
+    from agentarts.sdk import MemoryClient
+
+    client = MemoryClient(api_key=API_KEY, verify_ssl=VERIFY_SSL)
+    try:
+        messages = client.get_last_k_messages(
+            space_id=SPACE_ID,
+            session_id=session_id,
+            k=k,
+        )
+
+        result = []
+        for msg in messages:
+            if isinstance(msg, dict):
+                role = msg.get("role", "")
+            else:
+                role = getattr(msg, "role", "")
+
+            content = extract_message_content(msg)
+
+            if role in ("user", "assistant") and content:
+                result.append((role, content))
+
+        return result
+    finally:
+        client.close()

--- a/examples/navigation_langgraph_memory/nav_agent.py
+++ b/examples/navigation_langgraph_memory/nav_agent.py
@@ -1,0 +1,286 @@
+"""
+Navigation Agent Demo - LangGraph Agent with AgentArts Memory
+
+A local interactive navigation assistant that can:
+  - Search for POIs (gas stations, restaurants, parking, etc.)
+  - Plan routes (driving/walking/riding/transit)
+  - Generate map visualization links
+  - Recall long-term user preferences and history via AgentArts Memory
+
+Conversation state is persisted through AgentArtsMemorySessionSaver
+(native SDK LangGraph checkpointer). The backend auto-extracts
+memories using the four builtin strategies; the recall_memory tool
+provides active semantic search for historical context.
+
+Prerequisites:
+  1. Install dependencies:
+       uv sync --extra langgraph --extra tui
+     Or: pip install -r examples/navigation_langgraph_memory/requirements.txt
+  2. Copy env template and fill in credentials:
+       cp examples/navigation_langgraph_memory/.env.example examples/navigation_langgraph_memory/.env
+  3. Create memory space (writes SPACE_ID + API_KEY to .env):
+       uv run python examples/navigation_langgraph_memory/setup_memory.py
+  4. Fill in LLM credentials in .env (OPENAI_API_KEY, etc.)
+  5. (Optional) Set AMAP_KEY in .env for real AMap API calls
+
+Usage:
+  uv run python examples/navigation_langgraph_memory/nav_agent.py          # TUI mode (default)
+  uv run python examples/navigation_langgraph_memory/nav_agent.py --cli    # Classic CLI mode
+  uv run python examples/navigation_langgraph_memory/nav_agent.py --debug  # Show SDK logs
+"""
+
+import os
+import sys
+
+import config  # noqa: F401  (sets env vars as side effect)
+from config import (
+    ACTOR_ID,
+    API_KEY,
+    ASSISTANT_ID,
+    OPENAI_API_KEY,
+    OPENAI_BASE_URL,
+    OPENAI_MODEL_NAME,
+    SPACE_ID,
+    VERIFY_SSL,
+)
+
+
+def _check_env():
+    """Validate that required env vars are set before building the agent."""
+    missing = []
+    if not SPACE_ID:
+        missing.append("AGENTARTS_MEMORY_SPACE_ID")
+    if not API_KEY:
+        missing.append("HUAWEICLOUD_SDK_MEMORY_API_KEY")
+    if not OPENAI_API_KEY:
+        missing.append("OPENAI_API_KEY")
+
+    if missing:
+        print("[ERR] Missing required environment variables:")
+        for v in missing:
+            print(f"    - {v}")
+        print("\nRun setup first:  uv run python examples/navigation_langgraph_memory/setup_memory.py")
+        print("Then export the printed variables and your OPENAI_API_KEY.")
+        sys.exit(1)
+
+
+def build_agent():
+    """Build and compile the LangGraph navigation agent."""
+    # Imports are deferred so _check_env() runs first and fails fast
+    # without importing heavy modules.
+    from langchain_core.messages import SystemMessage
+    from langchain_openai import ChatOpenAI
+    from langgraph.graph import END, MessagesState, START, StateGraph
+    from langgraph.prebuilt import ToolNode
+
+    from agentarts.sdk.integration.langgraph import AgentArtsMemorySessionSaver
+
+    from amap_tools import generate_map_link, geocode_address, plan_route, search_poi
+    from memory_tools import recall_memory
+
+    SYSTEM_PROMPT = """\
+You are a navigation assistant that helps users find places and plan routes.
+
+Available tools:
+- geocode_address: Convert a place name (e.g. "中关村") to coordinates.
+  Call this FIRST when the user gives a place name and you need coordinates
+  for plan_route or nearby search_poi.
+- search_poi: Search for POIs (gas stations, restaurants, parking, etc.).
+  Supports nearby search when location coordinates are provided.
+- plan_route: Plan a route (driving/walking/riding/transit). Supports
+  waypoints for driving and requires city for transit.
+- generate_map_link: Generate a map visualization URL for locations
+- recall_memory: Recall user preferences and history (only call when the
+  user references past preferences or history; do NOT call every turn)
+
+Rules:
+- Coordinates use "longitude,latitude" format, e.g. "116.481181,39.990021"
+- When the user gives a place name (e.g. "中关村"), call geocode_address
+  to get coordinates before planning routes or doing nearby search
+- If the user's location is unknown, ask which city or area they are in
+- When the user expresses a preference (e.g. "I like highways"), respond
+  naturally - the memory system saves it automatically
+- Use recall_memory sparingly, only when historical context is needed
+- Present POI options clearly with names and addresses before planning routes
+"""
+
+    all_tools = [geocode_address, search_poi, plan_route, generate_map_link, recall_memory]
+
+    llm = ChatOpenAI(
+        model=OPENAI_MODEL_NAME,
+        api_key=OPENAI_API_KEY,
+        base_url=OPENAI_BASE_URL or None,
+        temperature=0,
+    )
+    llm_with_tools = llm.bind_tools(all_tools)
+
+    def call_model(state: MessagesState):
+        """Invoke LLM with system prompt and current message state."""
+        messages = [SystemMessage(content=SYSTEM_PROMPT)] + state["messages"]
+        response = llm_with_tools.invoke(messages)
+        return {"messages": [response]}
+
+    def should_continue(state: MessagesState) -> str:
+        """Route to tools node if LLM made tool calls, else end."""
+        last = state["messages"][-1]
+        if getattr(last, "tool_calls", None):
+            return "tools"
+        return END
+
+    # Build graph: START -> agent -> (tools?) -> agent/END
+    workflow = StateGraph(MessagesState)
+    workflow.add_node("agent", call_model)
+    workflow.add_node("tools", ToolNode(all_tools))
+    workflow.add_edge(START, "agent")
+    workflow.add_conditional_edges("agent", should_continue)
+    workflow.add_edge("tools", "agent")
+
+    # Checkpointer: conversation persists to AgentArts Memory
+    # thread_id == session_id (created on-demand by session_manager.py)
+    checkpointer = AgentArtsMemorySessionSaver(
+        space_id=SPACE_ID,
+        api_key=API_KEY,
+        verify_ssl=VERIFY_SSL,
+        max_messages=20,
+    )
+
+    return workflow.compile(checkpointer=checkpointer), checkpointer
+
+
+def main():
+    """Entry point - dispatches to TUI or CLI mode."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Navigation Agent Demo (LangGraph + AgentArts Memory)")
+    parser.add_argument(
+        "--debug", action="store_true",
+        help="Show SDK INFO logs and debug prints (default: clean mode)")
+    parser.add_argument(
+        "--cli", action="store_true",
+        help="Use classic CLI interface (default: TUI)")
+    args = parser.parse_args()
+
+    import cli_flags
+    cli_flags.DEBUG = args.debug
+
+    # Suppress SDK INFO logs in clean mode (must be set before any SDK import)
+    if not cli_flags.DEBUG:
+        os.environ["AGENTARTS_LOG_LEVEL"] = "WARNING"
+
+    _check_env()
+
+    if args.cli:
+        main_cli()
+    else:
+        main_tui()
+
+
+def main_cli():
+    """Classic CLI mode - original implementation."""
+    print("=" * 60)
+    print("Navigation Agent Demo (LangGraph + AgentArts Memory)")
+    print("=" * 60)
+    print(f"  Space ID:   {SPACE_ID}")
+    print(f"  Model:      {OPENAI_MODEL_NAME}")
+    print(f"  AMap Key:   {'set' if config.AMAP_KEY else 'NOT set (using mock data)'}")
+    print("=" * 60)
+
+    # --- Session selection ---
+    import session_manager
+    session_id, session_title = session_manager.select_session_interactive()
+
+    # Validate session exists in current space
+    if not session_manager.validate_session(session_id):
+        print(f"\n[WARN] Session {session_id[:8]}... not found in current space.")
+        print("       This session may belong to a different space.")
+        print("       Creating a new session...")
+        new_session = session_manager.create_new_session(session_title)
+        session_id = new_session["session_id"]
+        session_title = new_session["title"]
+        print(f"[OK] New session created: {session_id[:8]}...")
+
+    # Set the active session for recall_memory tool
+    import memory_tools
+    memory_tools.set_current_session(session_id)
+
+    print(f"\n  Active Session ID: {session_id}")
+    print(f"  Session Title:     {session_title}")
+    print("=" * 60)
+    print("Type 'quit' / 'exit' to stop.")
+    print()
+
+    agent, checkpointer = build_agent()
+
+    from langchain_core.messages import HumanMessage
+
+    thread_config = {
+        "configurable": {
+            "thread_id": session_id,
+            "actor_id": ACTOR_ID,
+            "assistant_id": ASSISTANT_ID,
+        }
+    }
+
+    message_count = 0
+    title_auto_set = bool(session_title and not session_title.startswith("Session "))
+
+    try:
+        while True:
+            try:
+                user_input = input("you: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+
+            if not user_input:
+                continue
+            if user_input.lower() in ("quit", "exit", "q"):
+                break
+
+            # Auto-generate title from first message if not set
+            if not title_auto_set:
+                auto_title = user_input[:30] + ("..." if len(user_input) > 30 else "")
+                session_manager.update_session_title(session_id, auto_title)
+                session_title = auto_title
+                title_auto_set = True
+
+            result = agent.invoke(
+                {"messages": [HumanMessage(content=user_input)]},
+                config=thread_config,
+            )
+
+            message_count += 1
+            reply = result["messages"][-1]
+            reply_text = reply.content if hasattr(reply, "content") else str(reply)
+            print(f"agent: {reply_text}\n")
+    finally:
+        # Update session metadata on exit
+        session_manager.update_session(session_id, message_count)
+        checkpointer.close()
+        print(f"Session '{session_title}' ended. Conversation saved to AgentArts Memory.")
+
+
+def main_tui():
+    """TUI mode - Textual-based interactive interface."""
+    import cli_flags
+    from tui_encoding import ensure_utf8_streams
+    from tui_app import NavAgentApp, TUIStdoutBridge
+
+    ensure_utf8_streams()
+
+    app = NavAgentApp(debug=cli_flags.DEBUG)
+
+    # Redirect stdout to chat log
+    bridge = TUIStdoutBridge(app)
+    old_stdout = sys.stdout
+    sys.stdout = bridge
+
+    try:
+        app.run()
+    finally:
+        sys.stdout = old_stdout  # Restore
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/navigation_langgraph_memory/nav_agent.py
+++ b/examples/navigation_langgraph_memory/nav_agent.py
@@ -18,6 +18,7 @@ queries beyond the auto-injected context.
 Prerequisites:
   1. Install dependencies:
        uv sync --extra langgraph --extra tui
+       uv pip install langchain-openai
      Or: pip install -r examples/navigation_langgraph_memory/requirements.txt
   2. Copy env template and fill in credentials:
        cp examples/navigation_langgraph_memory/.env.example examples/navigation_langgraph_memory/.env
@@ -28,8 +29,8 @@ Prerequisites:
 
 Usage:
   uv run python examples/navigation_langgraph_memory/nav_agent.py          # TUI mode (default)
-  uv run python examples/navigation_langgraph_memory/nav_agent.py --cli    # Classic CLI mode
-  uv run python examples/navigation_langgraph_memory/nav_agent.py --debug  # Show SDK logs
+  uv run python examples/navigation_langgraph_memory/nav_agent.py --cli    # Classic CLI mode (no SDK logs)
+  uv run python examples/navigation_langgraph_memory/nav_agent.py --debug  # CLI mode + SDK INFO logs
 """
 
 import os
@@ -84,6 +85,7 @@ def build_agent():
 
     from amap_tools import generate_map_link, geocode_address, plan_route, search_poi
     from memory_tools import recall_memory
+    from prompts import SYSTEM_PROMPT
 
     class NavAgentState(MessagesState):
         """State with memory_context for auto-injected long-term memories.
@@ -94,34 +96,6 @@ def build_agent():
         """
 
         memory_context: str
-
-    SYSTEM_PROMPT = """\
-You are a navigation assistant that helps users find places and plan routes.
-
-Available tools:
-- geocode_address: Convert a place name (e.g. "中关村") to coordinates.
-  Call this FIRST when the user gives a place name and you need coordinates
-  for plan_route or nearby search_poi.
-- search_poi: Search for POIs (gas stations, restaurants, parking, etc.).
-  Supports nearby search when location coordinates are provided.
-- plan_route: Plan a route (driving/walking/riding/transit). Supports
-  waypoints for driving and requires city for transit.
-- generate_map_link: Generate a map visualization URL for locations
-- recall_memory: Deep recall tool for specific historical queries.
-  Relevant memories are auto-injected each turn (see [Memory Context]).
-  Only call this tool when you need details BEYOND the auto-injected context.
-
-Rules:
-- Coordinates use "longitude,latitude" format, e.g. "116.481181,39.990021"
-- When the user gives a place name (e.g. "中关村"), call geocode_address
-  to get coordinates before planning routes or doing nearby search
-- If the user's location is unknown, ask which city or area they are in
-- When the user expresses a preference (e.g. "I like highways"), respond
-  naturally - the memory system saves it automatically
-- Use recall_memory only for deep queries beyond the auto-injected
-  [Memory Context]; do NOT call it every turn
-- Present POI options clearly with names and addresses before planning routes
-"""
 
     all_tools = [geocode_address, search_poi, plan_route, generate_map_link, recall_memory]
 
@@ -227,32 +201,77 @@ Rules:
 
 
 def main():
-    """Entry point - dispatches to TUI or CLI mode."""
+    """Entry point - dispatches to TUI or CLI mode.
+
+    --debug implies CLI mode: SDK INFO logs scroll naturally in the
+    terminal instead of being wiped by TUI redraws.
+    """
     import argparse
 
     parser = argparse.ArgumentParser(
         description="Navigation Agent Demo (LangGraph + AgentArts Memory)")
     parser.add_argument(
         "--debug", action="store_true",
-        help="Show SDK INFO logs and debug prints (default: clean mode)")
+        help="CLI mode with SDK INFO logs visible (logs scroll in terminal)")
     parser.add_argument(
         "--cli", action="store_true",
-        help="Use classic CLI interface (default: TUI)")
+        help="Use classic CLI interface without SDK logs (default: TUI)")
     args = parser.parse_args()
 
     import cli_flags
     cli_flags.DEBUG = args.debug
 
-    # Suppress SDK INFO logs in clean mode (must be set before any SDK import)
     if not cli_flags.DEBUG:
         os.environ["AGENTARTS_LOG_LEVEL"] = "WARNING"
 
     _check_env()
 
-    if args.cli:
+    # --debug implies CLI: SDK logs scroll naturally instead of being
+    # wiped by TUI redraws
+    if args.debug or args.cli:
         main_cli()
     else:
         main_tui()
+
+
+def _print_debug_trace(event: dict):
+    """Print a debug trace of a LangGraph stream event.
+
+    Called per event from agent.stream(stream_mode="updates") in --debug
+    mode. Each event is {node_name: node_output}. Returns the final AI
+    reply text if this event contains the terminal agent response.
+    """
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    final_reply = None
+    for node_name, update in event.items():
+        if node_name == "auto_recall":
+            ctx = update.get("memory_context", "")
+            if ctx:
+                print("  [trace auto_recall] memories injected:")
+                for line in ctx.split("\n"):
+                    print(f"    {line}")
+            else:
+                print("  [trace auto_recall] no memories injected")
+        elif node_name == "agent":
+            for msg in update.get("messages", []):
+                if isinstance(msg, AIMessage):
+                    tool_calls = getattr(msg, "tool_calls", None)
+                    if tool_calls:
+                        for tc in tool_calls:
+                            name = tc.get("name", "?")
+                            args = tc.get("args", {})
+                            print(f"  [trace agent] -> tool call: {name}({args})")
+                    elif msg.content:
+                        final_reply = msg.content
+        elif node_name == "tools":
+            for msg in update.get("messages", []):
+                if isinstance(msg, ToolMessage):
+                    name = getattr(msg, "name", "?")
+                    content = getattr(msg, "content", "")
+                    preview = content[:500] + ("..." if len(content) > 500 else "")
+                    print(f"  [trace tools] {name} -> {preview}")
+    return final_reply
 
 
 def main_cli():
@@ -270,7 +289,8 @@ def main_cli():
     session_id, session_title = session_manager.select_session_interactive()
 
     # Validate session exists in current space
-    if not session_manager.validate_session(session_id):
+    is_resume = session_manager.validate_session(session_id)
+    if not is_resume:
         print(f"\n[WARN] Session {session_id[:8]}... not found in current space.")
         print("       This session may belong to a different space.")
         print("       Creating a new session...")
@@ -289,9 +309,27 @@ def main_cli():
     print("Type 'quit' / 'exit' to stop.")
     print()
 
+    # Show recent message history for resumed sessions (matches TUI behavior)
+    if is_resume:
+        from message_utils import fetch_session_history
+
+        try:
+            history = fetch_session_history(session_id)
+            if history:
+                print("  --- Recent Messages ---")
+                for role, content in history:
+                    print(f"  {role}: {content}")
+                print("  --- End History ---")
+            else:
+                print("  (No message history found.)")
+        except Exception as e:
+            print(f"  (Could not load message history: {e})")
+        print()
+
     agent, checkpointer, store = build_agent()
 
     from langchain_core.messages import HumanMessage
+    import cli_flags
 
     thread_config = {
         "configurable": {
@@ -302,6 +340,14 @@ def main_cli():
     }
 
     message_count = 0
+    # For resumed sessions, load existing count from sessions.json so we
+    # accumulate onto the historical total instead of overwriting it with
+    # this run's count (matches TUI behavior in tui_app.py).
+    if is_resume:
+        for s in session_manager.list_sessions():
+            if s["session_id"] == session_id:
+                message_count = s.get("message_count", 0)
+                break
     title_auto_set = bool(session_title and not session_title.startswith("Session "))
 
     try:
@@ -324,14 +370,27 @@ def main_cli():
                 session_title = auto_title
                 title_auto_set = True
 
-            result = agent.invoke(
-                {"messages": [HumanMessage(content=user_input)]},
-                config=thread_config,
-            )
+            if cli_flags.DEBUG:
+                # Stream mode: trace each node's output in real time
+                reply_text = None
+                for event in agent.stream(
+                    {"messages": [HumanMessage(content=user_input)]},
+                    config=thread_config,
+                    stream_mode="updates",
+                ):
+                    reply = _print_debug_trace(event)
+                    if reply:
+                        reply_text = reply
+                reply_text = reply_text or "(no response)"
+            else:
+                result = agent.invoke(
+                    {"messages": [HumanMessage(content=user_input)]},
+                    config=thread_config,
+                )
+                reply = result["messages"][-1]
+                reply_text = reply.content if hasattr(reply, "content") else str(reply)
 
             message_count += 1
-            reply = result["messages"][-1]
-            reply_text = reply.content if hasattr(reply, "content") else str(reply)
             print(f"agent: {reply_text}\n")
     finally:
         # Update session metadata on exit

--- a/examples/navigation_langgraph_memory/nav_agent.py
+++ b/examples/navigation_langgraph_memory/nav_agent.py
@@ -9,8 +9,11 @@ A local interactive navigation assistant that can:
 
 Conversation state is persisted through AgentArtsMemorySessionSaver
 (native SDK LangGraph checkpointer). The backend auto-extracts
-memories using the four builtin strategies; the recall_memory tool
-provides active semantic search for historical context.
+memories using the four builtin strategies. Long-term recall uses a
+hybrid approach: an auto_recall node searches AgentArtsMemoryStore
+(SDK LangGraph Store) before each LLM call to inject relevant memories,
+and the recall_memory tool provides on-demand deep search for specific
+queries beyond the auto-injected context.
 
 Prerequisites:
   1. Install dependencies:
@@ -68,15 +71,29 @@ def build_agent():
     """Build and compile the LangGraph navigation agent."""
     # Imports are deferred so _check_env() runs first and fails fast
     # without importing heavy modules.
-    from langchain_core.messages import SystemMessage
+    from langchain_core.messages import HumanMessage, SystemMessage
     from langchain_openai import ChatOpenAI
     from langgraph.graph import END, MessagesState, START, StateGraph
     from langgraph.prebuilt import ToolNode
+    from langgraph.store.base import BaseStore
 
-    from agentarts.sdk.integration.langgraph import AgentArtsMemorySessionSaver
+    from agentarts.sdk.integration.langgraph import (
+        AgentArtsMemorySessionSaver,
+        AgentArtsMemoryStore,
+    )
 
     from amap_tools import generate_map_link, geocode_address, plan_route, search_poi
     from memory_tools import recall_memory
+
+    class NavAgentState(MessagesState):
+        """State with memory_context for auto-injected long-term memories.
+
+        memory_context holds formatted memory text from the auto_recall
+        node. It uses the default (replace) reducer: each auto_recall
+        invocation overwrites the previous value.
+        """
+
+        memory_context: str
 
     SYSTEM_PROMPT = """\
 You are a navigation assistant that helps users find places and plan routes.
@@ -90,8 +107,9 @@ Available tools:
 - plan_route: Plan a route (driving/walking/riding/transit). Supports
   waypoints for driving and requires city for transit.
 - generate_map_link: Generate a map visualization URL for locations
-- recall_memory: Recall user preferences and history (only call when the
-  user references past preferences or history; do NOT call every turn)
+- recall_memory: Deep recall tool for specific historical queries.
+  Relevant memories are auto-injected each turn (see [Memory Context]).
+  Only call this tool when you need details BEYOND the auto-injected context.
 
 Rules:
 - Coordinates use "longitude,latitude" format, e.g. "116.481181,39.990021"
@@ -100,7 +118,8 @@ Rules:
 - If the user's location is unknown, ask which city or area they are in
 - When the user expresses a preference (e.g. "I like highways"), respond
   naturally - the memory system saves it automatically
-- Use recall_memory sparingly, only when historical context is needed
+- Use recall_memory only for deep queries beyond the auto-injected
+  [Memory Context]; do NOT call it every turn
 - Present POI options clearly with names and addresses before planning routes
 """
 
@@ -114,24 +133,77 @@ Rules:
     )
     llm_with_tools = llm.bind_tools(all_tools)
 
-    def call_model(state: MessagesState):
-        """Invoke LLM with system prompt and current message state."""
-        messages = [SystemMessage(content=SYSTEM_PROMPT)] + state["messages"]
+    def auto_recall(state: NavAgentState, *, store: BaseStore) -> dict:
+        """Search Store for relevant long-term memories, inject as context.
+
+        Runs before the agent node each turn. Searches the
+        AgentArtsMemoryStore for memories matching the user's latest
+        message, filtered by actor_id (cross-session, user-scoped).
+        Results are stored in state["memory_context"] and appended to
+        the system prompt by call_model. Failures are silent -- the
+        agent continues without memories.
+        """
+        if not config.AUTO_RECALL_ENABLED:
+            return {"memory_context": ""}
+
+        last_msg = state["messages"][-1]
+        if not isinstance(last_msg, HumanMessage):
+            return {"memory_context": ""}
+
+        query = last_msg.content
+        try:
+            items = store.search(
+                (),
+                query=query,
+                filter={"actor_id": config.ACTOR_ID},
+                limit=config.AUTO_RECALL_TOP_K,
+            )
+        except Exception as e:
+            # Graceful degradation: never block the agent
+            import logging
+            logging.getLogger(__name__).warning(
+                f"Auto-recall failed, continuing without memories: {e}")
+            return {"memory_context": ""}
+
+        if not items:
+            return {"memory_context": ""}
+
+        lines = []
+        for item in items:
+            content = item.value.get("content", "")
+            strategy = item.value.get("strategy_type", "")
+            if content:
+                tag = f"[{strategy}] " if strategy else ""
+                lines.append(f"- {tag}{content}")
+
+        if not lines:
+            return {"memory_context": ""}
+        return {"memory_context": "\n".join(lines)}
+
+    def call_model(state: NavAgentState):
+        """Invoke LLM with system prompt, memory context, and message state."""
+        system_content = SYSTEM_PROMPT
+        memory_ctx = state.get("memory_context", "")
+        if memory_ctx:
+            system_content += f"\n\n[Memory Context]\n{memory_ctx}"
+        messages = [SystemMessage(content=system_content)] + state["messages"]
         response = llm_with_tools.invoke(messages)
         return {"messages": [response]}
 
-    def should_continue(state: MessagesState) -> str:
+    def should_continue(state: NavAgentState) -> str:
         """Route to tools node if LLM made tool calls, else end."""
         last = state["messages"][-1]
         if getattr(last, "tool_calls", None):
             return "tools"
         return END
 
-    # Build graph: START -> agent -> (tools?) -> agent/END
-    workflow = StateGraph(MessagesState)
+    # Build graph: START -> auto_recall -> agent -> (tools?) -> agent/END
+    workflow = StateGraph(NavAgentState)
+    workflow.add_node("auto_recall", auto_recall)
     workflow.add_node("agent", call_model)
     workflow.add_node("tools", ToolNode(all_tools))
-    workflow.add_edge(START, "agent")
+    workflow.add_edge(START, "auto_recall")
+    workflow.add_edge("auto_recall", "agent")
     workflow.add_conditional_edges("agent", should_continue)
     workflow.add_edge("tools", "agent")
 
@@ -144,7 +216,14 @@ Rules:
         max_messages=20,
     )
 
-    return workflow.compile(checkpointer=checkpointer), checkpointer
+    # Store: cross-session long-term memory for auto-injection
+    store = AgentArtsMemoryStore(
+        space_id=SPACE_ID,
+        api_key=API_KEY,
+        verify_ssl=VERIFY_SSL,
+    )
+
+    return workflow.compile(checkpointer=checkpointer, store=store), checkpointer, store
 
 
 def main():
@@ -210,7 +289,7 @@ def main_cli():
     print("Type 'quit' / 'exit' to stop.")
     print()
 
-    agent, checkpointer = build_agent()
+    agent, checkpointer, store = build_agent()
 
     from langchain_core.messages import HumanMessage
 
@@ -258,6 +337,7 @@ def main_cli():
         # Update session metadata on exit
         session_manager.update_session(session_id, message_count)
         checkpointer.close()
+        store.close()
         print(f"Session '{session_title}' ended. Conversation saved to AgentArts Memory.")
 
 

--- a/examples/navigation_langgraph_memory/prompts.py
+++ b/examples/navigation_langgraph_memory/prompts.py
@@ -1,0 +1,35 @@
+"""Navigation Agent Demo - System Prompts
+
+Centralized prompt definitions for the navigation agent.
+Separated from code so prompts can be iterated independently.
+"""
+
+SYSTEM_PROMPT = """\
+You are a navigation assistant that helps users find places and plan routes.
+
+Available tools:
+- geocode_address: Convert a place name (e.g. "中关村") to coordinates.
+  Call this FIRST when the user gives a place name and you need coordinates
+  for plan_route or nearby search_poi.
+- search_poi: Search for POIs (gas stations, restaurants, parking, etc.).
+  Supports nearby search when location coordinates are provided.
+- plan_route: Plan a route (driving/walking/riding/transit). Supports
+  waypoints for driving and requires city for transit.
+- generate_map_link: Generate a map visualization URL for locations
+- recall_memory: Search long-term memories with a targeted query.
+  The [Memory Context] above is a lightweight preview (top 3).
+  Call this when the preview doesn't contain what the user needs,
+  or when the user references past preferences or prior conversations.
+
+Rules:
+- Coordinates use "longitude,latitude" format, e.g. "116.481181,39.990021"
+- When the user gives a place name (e.g. "中关村"), call geocode_address
+  to get coordinates before planning routes or doing nearby search
+- If the user's location is unknown, ask which city or area they are in
+- When the user expresses a preference (e.g. "I like highways"), respond
+  naturally - the memory system saves it automatically
+- When [Memory Context] is empty or doesn't answer the user's question
+  about past interactions, call recall_memory with a specific query —
+  it returns up to 5 results vs the preview's 3
+- Present POI options clearly with names and addresses before planning routes
+"""

--- a/examples/navigation_langgraph_memory/requirements.txt
+++ b/examples/navigation_langgraph_memory/requirements.txt
@@ -1,0 +1,19 @@
+# Navigation Agent Demo - Dependencies
+# Install with: pip install -r requirements.txt
+# Or with uv: uv sync --extra langgraph --extra tui
+
+# AgentArts SDK (install from project root first)
+# uv sync  OR  pip install -e .
+
+# LangGraph + LangChain
+langgraph>=1.0.0
+langchain>=0.1.0
+langchain-core>=0.1.0
+langchain-openai>=0.1.0
+
+# TUI
+textual>=0.86.0
+
+# Utilities
+requests>=2.31.0
+python-dotenv>=1.0.0

--- a/examples/navigation_langgraph_memory/session_manager.py
+++ b/examples/navigation_langgraph_memory/session_manager.py
@@ -1,0 +1,179 @@
+"""
+Navigation Agent Demo - Session Manager
+
+Manages multiple conversation sessions locally. Each session maps to
+an AgentArts Memory session (via session_id). Session metadata is
+persisted to sessions.json so sessions survive restarts.
+
+Usage:
+    from session_manager import select_session_interactive
+    session_id = select_session_interactive()
+"""
+
+import json
+import os
+from datetime import datetime
+
+import cli_flags  # noqa: F401
+import config  # noqa: F401  (sets env vars as side effect)
+from agentarts.sdk import MemoryClient
+
+SESSIONS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sessions.json")
+
+
+def load_sessions() -> list[dict]:
+    """Load session metadata from local JSON file."""
+    try:
+        with open(SESSIONS_FILE, encoding="utf-8") as f:
+            data = json.load(f)
+            return data.get("sessions", [])
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
+
+def save_sessions(sessions: list[dict]):
+    """Save session metadata to local JSON file."""
+    with open(SESSIONS_FILE, "w", encoding="utf-8") as f:
+        json.dump({"sessions": sessions}, f, ensure_ascii=False, indent=2)
+
+
+def list_sessions() -> list[dict]:
+    """Return all sessions sorted by last_active (newest first)."""
+    sessions = load_sessions()
+    sessions.sort(key=lambda s: s.get("last_active", ""), reverse=True)
+    return sessions
+
+
+def create_new_session(title: str = "") -> dict:
+    """Create a new AgentArts Memory session and add to local store.
+
+    Args:
+        title: Optional session title. If empty, auto-generated from
+            the session ID prefix (updated later from first message).
+
+    Returns:
+        Session metadata dict with session_id, title, timestamps.
+    """
+    client = MemoryClient(api_key=config.API_KEY, verify_ssl=config.VERIFY_SSL)
+    try:
+        session = client.create_memory_session(
+            space_id=config.SPACE_ID,
+            actor_id=config.ACTOR_ID,
+            assistant_id=config.ASSISTANT_ID,
+        )
+    finally:
+        client.close()
+
+    now = datetime.now().isoformat(timespec="seconds")
+    entry = {
+        "session_id": session.id,
+        "title": title or f"Session {session.id[:8]}",
+        "created_at": now,
+        "last_active": now,
+        "message_count": 0,
+    }
+
+    sessions = load_sessions()
+    sessions.append(entry)
+    save_sessions(sessions)
+
+    return entry
+
+
+def update_session(session_id: str, message_count: int = 0):
+    """Update last_active timestamp and message_count for a session."""
+    sessions = load_sessions()
+    now = datetime.now().isoformat(timespec="seconds")
+    for s in sessions:
+        if s["session_id"] == session_id:
+            s["last_active"] = now
+            if message_count:
+                s["message_count"] = message_count
+            break
+    save_sessions(sessions)
+
+
+def update_session_title(session_id: str, title: str):
+    """Update the title for a session (e.g. from first user message)."""
+    sessions = load_sessions()
+    for s in sessions:
+        if s["session_id"] == session_id:
+            s["title"] = title[:50]
+            break
+    save_sessions(sessions)
+
+
+def validate_session(session_id: str) -> bool:
+    """Check if a session exists in the current space.
+
+    Calls list_messages with limit=1 to verify the session is accessible.
+    Returns True if the API call succeeds (session exists, may be empty),
+    False if the API call fails (session doesn't exist in this space).
+    """
+    client = MemoryClient(api_key=config.API_KEY, verify_ssl=config.VERIFY_SSL)
+    try:
+        client.list_messages(
+            space_id=config.SPACE_ID,
+            session_id=session_id,
+            limit=1,
+            offset=0,
+        )
+        return True
+    except Exception as e:
+        if cli_flags.DEBUG:
+            print(f"[DEBUG] Session validation failed: {e}")
+        return False
+    finally:
+        client.close()
+
+
+def select_session_interactive() -> tuple[str, str]:
+    """Interactive CLI: show menu, let user pick or create a session.
+
+    Returns:
+        Tuple of (session_id, session_title).
+    """
+    sessions = list_sessions()
+
+    print("\n" + "=" * 60)
+    print("Session Manager")
+    print("=" * 60)
+    print("[1] Start new session")
+
+    start_index = 2
+    if sessions:
+        print("[2] Resume existing session:\n")
+        for i, s in enumerate(sessions):
+            title = s.get("title", "untitled")
+            ts = s.get("last_active", "?")
+            count = s.get("message_count", 0)
+            print(f"    [{i + 3}] {title}")
+            print(f"        last: {ts}, messages: {count}")
+        start_index = 3
+    else:
+        print("    (no existing sessions)")
+
+    choice = input("\nChoice: ").strip()
+
+    if choice == "1":
+        title = input("Session title (optional, Enter to auto-generate): ").strip()
+        session = create_new_session(title)
+        print(f"\n[OK] New session created: {session['session_id']}")
+        return session["session_id"], session["title"]
+
+    if choice == "2" and not sessions:
+        print("[ERR] No existing sessions. Creating new one.")
+        session = create_new_session("")
+        return session["session_id"], session["title"]
+
+    # Numeric choice for existing session
+    if choice.isdigit():
+        idx = int(choice) - 3  # offset: [3] is first session
+        if 0 <= idx < len(sessions):
+            s = sessions[idx]
+            print(f"\n[OK] Resuming session: {s['title']}")
+            return s["session_id"], s["title"]
+
+    print("[ERR] Invalid choice, creating new session.")
+    session = create_new_session("")
+    return session["session_id"], session["title"]

--- a/examples/navigation_langgraph_memory/setup_memory.py
+++ b/examples/navigation_langgraph_memory/setup_memory.py
@@ -1,0 +1,144 @@
+"""
+Navigation Agent Demo - Memory Space Setup (run once)
+
+Creates a new AgentArts Memory space with all four builtin extraction
+strategies. Prints the Space ID and API Key that must be exported as
+environment variables before running nav_agent.py.
+
+Sessions are NOT created here — session_manager.py creates a new
+AgentArts Memory session for each conversation at agent startup.
+
+Usage:
+    uv run python examples/navigation_langgraph_memory/setup_memory.py
+"""
+
+import json
+import os
+import time
+
+import config  # noqa: F401  (sets env vars as side effect)
+from agentarts.sdk import MemoryClient
+
+from config import BUILTIN_STRATEGIES, SPACE_DESCRIPTION, SPACE_NAME
+
+
+def _check_and_clear_sessions_json():
+    """Check if sessions.json exists and prompt user to clear it.
+
+    Sessions are bound to a specific space. When creating a new space,
+    old session IDs from sessions.json won't work with the new space.
+    """
+    sessions_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sessions.json")
+
+    if not os.path.exists(sessions_file):
+        return
+
+    try:
+        with open(sessions_file, encoding="utf-8") as f:
+            data = json.load(f)
+            sessions = data.get("sessions", [])
+    except (FileNotFoundError, json.JSONDecodeError):
+        return
+
+    if not sessions:
+        return
+
+    print(f"\n[!] Found {len(sessions)} existing session(s) in sessions.json.")
+    print("    Sessions are bound to a specific space. Old sessions won't work")
+    print("    with the new space you just created.")
+    print()
+
+    while True:
+        choice = input("Clear sessions.json? [y/N]: ").strip().lower()
+        if choice in ("y", "yes"):
+            with open(sessions_file, "w", encoding="utf-8") as f:
+                json.dump({"sessions": []}, f, ensure_ascii=False, indent=2)
+            print("[OK] sessions.json cleared.")
+            return
+        elif choice in ("n", "no", ""):
+            print("[WARN] sessions.json not cleared. Old sessions will not work")
+            print("       with the new space. You may need to manually delete")
+            print("       sessions.json or create new sessions in nav_agent.py.")
+            return
+        else:
+            print("Please enter 'y' or 'n'.")
+
+
+def main():
+    """Create memory space and write credentials to .env file."""
+    print("=" * 60)
+    print("Navigation Agent - Memory Space Setup")
+    print("=" * 60)
+
+    # --- Phase 1: Control plane - create space (no api_key needed) ---
+    print("\n[1/2] Creating memory space...")
+    client = MemoryClient(verify_ssl=config.VERIFY_SSL)
+    try:
+        space = client.create_space(
+            name=SPACE_NAME,
+            memory_strategies_builtin=BUILTIN_STRATEGIES,
+            memory_extract_idle_seconds=30,
+            description=SPACE_DESCRIPTION,
+        )
+    finally:
+        client.close()
+
+    print(f"  Space ID:   {space.id}")
+    print(f"  API Key:    {space.api_key}")
+    print(f"  Strategies: {space.memory_strategies_builtin}")
+
+    # Wait for API key to propagate to the data plane
+    print("\n  Waiting 5s for API key propagation...")
+    time.sleep(5)
+
+    # --- Phase 2: Write .env file ---
+    print("\n[2/2] Setup complete.")
+
+    env_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+
+    # Read existing .env if present, merge new values
+    existing_lines = []
+    if os.path.exists(env_file):
+        with open(env_file, encoding="utf-8") as f:
+            existing_lines = f.readlines()
+
+    new_vars = {
+        "AGENTARTS_MEMORY_SPACE_ID": space.id,
+        "HUAWEICLOUD_SDK_MEMORY_API_KEY": space.api_key,
+    }
+
+    updated_keys = set()
+    output_lines = []
+    for line in existing_lines:
+        stripped = line.strip()
+        matched = False
+        for key, val in new_vars.items():
+            if stripped.startswith(f"{key}="):
+                output_lines.append(f'{key}="{val}"\n')
+                updated_keys.add(key)
+                matched = True
+                break
+        if not matched:
+            output_lines.append(line)
+
+    # Append any keys not yet in the file
+    for key, val in new_vars.items():
+        if key not in updated_keys:
+            output_lines.append(f'{key}="{val}"\n')
+
+    with open(env_file, "w", encoding="utf-8") as f:
+        f.writelines(output_lines)
+
+    print(f"  Written to: {env_file}")
+    print(f"  Space ID:   {space.id}")
+    print(f"  API Key:    {space.api_key}")
+
+    # Check if sessions.json needs to be cleared
+    _check_and_clear_sessions_json()
+
+    print("\nThen start the agent:")
+    print("  uv run python examples/navigation_langgraph_memory/nav_agent.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/navigation_langgraph_memory/tui_app.py
+++ b/examples/navigation_langgraph_memory/tui_app.py
@@ -355,33 +355,18 @@ class NavAgentApp(App):
 
     def _show_message_history(self, chat_log: RichLog, session_id: str) -> None:
         """Fetch and display recent messages from the session."""
-        client = None
+        from message_utils import fetch_session_history
+
         try:
-            from agentarts.sdk import MemoryClient
+            history = fetch_session_history(session_id)
 
-            client = MemoryClient(api_key=config.API_KEY, verify_ssl=config.VERIFY_SSL)
-            messages = client.get_last_k_messages(
-                space_id=config.SPACE_ID,
-                session_id=session_id,
-                k=20
-            )
-
-            if not messages:
+            if not history:
                 chat_log.write("[dim]No message history found.[/]")
                 return
 
-            # Filter and display messages (oldest first, newest last)
+            # Display messages (oldest first, newest last)
             chat_log.write("[dim]--- Recent Messages ---[/]")
-            for msg in messages:
-                # Extract role
-                if isinstance(msg, dict):
-                    role = msg.get('role', '')
-                    content = self._extract_content(msg)
-                else:
-                    role = getattr(msg, 'role', '')
-                    content = self._extract_content(msg)
-
-                # Only show user and agent messages, skip tool calls
+            for role, content in history:
                 if role == 'user':
                     chat_log.write(f"[cyan]you:[/] {content}")
                 elif role == 'assistant':
@@ -396,42 +381,6 @@ class NavAgentApp(App):
                 import traceback
                 chat_log.write(f"[dim]{traceback.format_exc()}[/]")
             chat_log.write("")
-        finally:
-            if client:
-                try:
-                    client.close()
-                except Exception:
-                    pass
-
-    def _extract_content(self, msg) -> str:
-        """Extract text content from message (handles both dict and MessageInfo)."""
-        # MessageInfo has 'parts' field: [{'type': 'text', 'text': '...'}]
-        if isinstance(msg, dict):
-            parts = msg.get('parts', [])
-        else:
-            parts = getattr(msg, 'parts', [])
-
-        if parts:
-            # Extract text from parts (handle both dict and object)
-            texts = []
-            for p in parts:
-                # Check if part is a dict or object
-                if isinstance(p, dict):
-                    part_type = p.get('type')
-                    part_text = p.get('text', '')
-                else:
-                    part_type = getattr(p, 'type', None)
-                    part_text = getattr(p, 'text', '')
-
-                if part_type == 'text':
-                    texts.append(part_text)
-            return ' '.join(texts)
-
-        # Fallback: try content field
-        if isinstance(msg, dict):
-            return msg.get('content', '')
-        else:
-            return getattr(msg, 'content', '') or str(msg)
 
     def _build_agent(self) -> None:
         """Build the LangGraph agent."""

--- a/examples/navigation_langgraph_memory/tui_app.py
+++ b/examples/navigation_langgraph_memory/tui_app.py
@@ -1,0 +1,545 @@
+"""Navigation Agent TUI application using Textual framework."""
+import asyncio
+import io
+import threading
+from typing import Optional
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import Button, Footer, Header, Input, Label, ListItem, ListView, RichLog
+from textual.binding import Binding
+
+import memory_tools
+import session_manager
+import config
+from config import SPACE_ID, OPENAI_MODEL_NAME
+
+
+class TUIStdoutBridge(io.TextIOBase):
+    """Thread-safe stdout bridge that redirects print() to RichLog."""
+
+    def __init__(self, app: "NavAgentApp"):
+        """Initialize bridge with app reference and thread lock."""
+        self.app = app
+        self.lock = threading.Lock()
+
+    def write(self, s: str) -> int:
+        """Write string to chat log with thread safety."""
+        if not s.strip():
+            return len(s)
+        with self.lock:
+            try:
+                chat_log = self.app.query_one("#chat_log", RichLog)
+                # Use dim style for SDK prints to distinguish from user/agent messages
+                chat_log.write(f"[dim]{s.strip()}[/]")
+            except Exception:
+                # App might be closed, ignore
+                pass
+        return len(s)
+
+    def flush(self):
+        """No-op flush for compatibility."""
+        pass
+
+
+class SessionSelectScreen(ModalScreen[tuple[Optional[str], Optional[str], bool]]):
+    """Modal screen for session selection."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("tab", "focus_next", "Next", show=False),
+        Binding("shift+tab", "focus_previous", "Previous", show=False),
+        Binding("ctrl+t", "focus_title_input", "Title Input"),
+    ]
+
+    def __init__(self):
+        """Initialize session list and selection state."""
+        super().__init__()
+        self.sessions = session_manager.list_sessions()
+        self._selected_index = 0
+
+    def compose(self) -> ComposeResult:
+        """Build session selection dialog with list, input, and buttons."""
+        with Container(id="session-dialog"):
+            yield Label("Select Session", id="dialog-title")
+
+            # Create list view with options
+            items = []
+
+            # Option 1: New session
+            items.append(ListItem(Label("[bold green]+ Create New Session[/]")))
+
+            # Existing sessions
+            for s in self.sessions:
+                title = s.get("title", "untitled")
+                ts = s.get("last_active", "?")
+                count = s.get("message_count", 0)
+                items.append(
+                    ListItem(Label(f"[cyan]{title}[/] [dim](last: {ts}, msgs: {count})[/]"))
+                )
+
+            yield ListView(*items, id="session-list")
+
+            # Title input (for new session title, or new name for renaming)
+            yield Input(
+                placeholder="Type new name to rename selected session",
+                id="title-input",
+            )
+
+            with Container(id="button-row"):
+                yield Button("Confirm", variant="primary", id="confirm-btn")
+                yield Button("Rename", variant="warning", id="rename-btn")
+                yield Button("Cancel", variant="default", id="cancel-btn")
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        """Track cursor position as user navigates with arrow keys."""
+        self._selected_index = event.list_view.index or 0
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        """Handle list item selection - Enter on item triggers confirm directly."""
+        self._selected_index = event.list_view.index or 0
+        # Directly confirm selection on Enter (no need to click button)
+        self._confirm()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button press."""
+        if event.button.id == "cancel-btn":
+            self.dismiss((None, None, False))
+        elif event.button.id == "confirm-btn":
+            self._confirm()
+        elif event.button.id == "rename-btn":
+            self._rename()
+
+    def _confirm(self) -> None:
+        """Confirm selection and dismiss."""
+        idx = self._selected_index
+        title_input = self.query_one("#title-input", Input)
+        title = title_input.value.strip()
+
+        if idx == 0:
+            # Create new session
+            session = session_manager.create_new_session(title)
+            self.dismiss((session["session_id"], session["title"], True))
+        else:
+            # Resume existing session
+            session_idx = idx - 1  # offset for "new session" option
+            if 0 <= session_idx < len(self.sessions):
+                s = self.sessions[session_idx]
+                self.dismiss((s["session_id"], s["title"], False))
+            else:
+                self.notify("Invalid selection", severity="error")
+
+    def _rename(self) -> None:
+        """Rename the selected session."""
+        idx = self._selected_index
+        title_input = self.query_one("#title-input", Input)
+        new_title = title_input.value.strip()
+
+        # Validation
+        if idx == 0:
+            self.notify("Cannot rename 'Create New Session'", severity="warning")
+            return
+
+        if not new_title:
+            self.notify("Please enter a new name", severity="warning")
+            return
+
+        session_idx = idx - 1  # offset for "new session" option
+        if not (0 <= session_idx < len(self.sessions)):
+            self.notify("Invalid selection", severity="error")
+            return
+
+        # Perform rename
+        session_id = self.sessions[session_idx]["session_id"]
+        session_manager.update_session_title(session_id, new_title)
+
+        # Update local data
+        self.sessions[session_idx]["title"] = new_title[:50]
+
+        # Update ListView display
+        list_view = self.query_one("#session-list", ListView)
+        # ListView children are indexed; rebuild the label for the renamed item
+        # idx is the position in the list (0 = "Create New Session", 1..N = sessions)
+        children = list(list_view.children)
+        if idx < len(children):
+            item = children[idx]
+            # Find the Label widget inside the ListItem
+            label = item.query_one(Label)
+            s = self.sessions[session_idx]
+            ts = s.get("last_active", "?")
+            count = s.get("message_count", 0)
+            label.update(f"[cyan]{new_title[:50]}[/] [dim](last: {ts}, msgs: {count})[/]")
+
+        # Clear input and show success
+        title_input.value = ""
+        self.notify(f"Renamed to: {new_title[:50]}")
+
+        # Keep focus on the list for further navigation
+        list_view.focus()
+
+    def action_cancel(self) -> None:
+        """Cancel and dismiss."""
+        self.dismiss((None, None, False))
+
+    def action_focus_title_input(self) -> None:
+        """Focus the title input field."""
+        title_input = self.query_one("#title-input", Input)
+        title_input.focus()
+
+    def on_key(self, event) -> None:
+        """Handle key events to ensure Tab navigation works."""
+        if event.key == "tab":
+            # Move focus to next widget
+            self.focus_next()
+            event.prevent_default()
+            event.stop()
+        elif event.key == "shift+tab":
+            # Move focus to previous widget
+            self.focus_previous()
+            event.prevent_default()
+            event.stop()
+
+
+class NavAgentApp(App):
+    """Navigation Agent TUI application."""
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #chat_log {
+        height: 1fr;
+        border: solid $primary;
+        margin: 1;
+    }
+
+    #user_input {
+        margin: 0 1;
+    }
+
+    #session-dialog {
+        width: 80;
+        height: auto;
+        max-height: 80%;
+        border: thick $primary 80%;
+        background: $surface;
+        padding: 1;
+    }
+
+    #dialog-title {
+        text-align: center;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #session-list {
+        height: 15;
+        margin-bottom: 1;
+    }
+
+    #title-input {
+        margin-bottom: 1;
+    }
+
+    #button-row {
+        layout: horizontal;
+        height: auto;
+        align: center middle;
+    }
+
+    #button-row Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("ctrl+c", "quit", "Quit"),
+        Binding("ctrl+l", "clear_log", "Clear Log"),
+    ]
+
+    def __init__(self, debug: bool = False):
+        """Initialize app state for session management and agent interaction."""
+        super().__init__()
+        # Use _debug to avoid conflict with App.debug property
+        self._debug = debug
+        self._agent = None
+        self._checkpointer = None
+        self._thread_config = None
+        self._session_id = None
+        self._session_title = None
+        self._message_count = 0
+        self._title_auto_set = False
+
+    def compose(self) -> ComposeResult:
+        """Compose the UI layout."""
+        yield Header(show_clock=False)
+        yield RichLog(id="chat_log", auto_scroll=True, wrap=True, markup=True)
+        yield Input(id="user_input", placeholder="Type your message (or quit/exit)")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        """Initialize app after mount."""
+        chat_log = self.query_one("#chat_log", RichLog)
+
+        # Show banner
+        chat_log.write("[bold blue]Navigation Agent Demo[/]")
+        chat_log.write(f"[dim]Space ID:   {SPACE_ID}[/]")
+        chat_log.write(f"[dim]Model:      {OPENAI_MODEL_NAME}[/]")
+        amap_status = "set" if config.AMAP_KEY else "NOT set (using mock data)"
+        chat_log.write(f"[dim]AMap Key:   {amap_status}[/]")
+        chat_log.write("")
+
+        # Push session selection screen
+        self.push_screen(SessionSelectScreen(), self._on_session_selected)
+
+    def _on_session_selected(
+        self, result: tuple[Optional[str], Optional[str], bool]
+    ) -> None:
+        """Handle session selection result."""
+        session_id, session_title, is_new = result
+
+        if session_id is None:
+            # User cancelled
+            self.exit()
+            return
+
+        self._session_id = session_id
+        self._session_title = session_title
+
+        # For resumed sessions, don't auto-set title on first message
+        if not is_new:
+            self._title_auto_set = True
+            # Load existing message count from sessions.json
+            for s in session_manager.list_sessions():
+                if s["session_id"] == session_id:
+                    self._message_count = s.get("message_count", 0)
+                    break
+
+        chat_log = self.query_one("#chat_log", RichLog)
+
+        # Validate session if resuming
+        if not is_new:
+            if not session_manager.validate_session(session_id):
+                chat_log.write(
+                    f"[yellow]Session {session_id[:8]}... not found in current space.[/]"
+                )
+                chat_log.write("[yellow]Creating a new session...[/]")
+                new_session = session_manager.create_new_session(session_title)
+                self._session_id = new_session["session_id"]
+                self._session_title = new_session["title"]
+                self._message_count = 0  # Reset for new session
+                chat_log.write(f"[green]New session created: {self._session_id[:8]}...[/]")
+            else:
+                chat_log.write(f"[green]Resuming session: {session_title}[/]")
+                # Show recent message history
+                self._show_message_history(chat_log, self._session_id)
+        else:
+            chat_log.write(f"[green]New session: {self._session_title}[/]")
+
+        chat_log.write(f"[dim]Session ID: {self._session_id}[/]")
+        chat_log.write("")
+        chat_log.write("[dim]Type 'quit' or 'exit' to stop.[/]")
+        chat_log.write("")
+
+        # Set session for memory tools
+        memory_tools.set_current_session(self._session_id)
+
+        # Build agent
+        self._build_agent()
+
+        # Focus input
+        self.query_one("#user_input", Input).focus()
+
+    def _show_message_history(self, chat_log: RichLog, session_id: str) -> None:
+        """Fetch and display recent messages from the session."""
+        client = None
+        try:
+            from agentarts.sdk import MemoryClient
+
+            client = MemoryClient(api_key=config.API_KEY, verify_ssl=config.VERIFY_SSL)
+            messages = client.get_last_k_messages(
+                space_id=config.SPACE_ID,
+                session_id=session_id,
+                k=20
+            )
+
+            if not messages:
+                chat_log.write("[dim]No message history found.[/]")
+                return
+
+            # Filter and display messages (oldest first, newest last)
+            chat_log.write("[dim]--- Recent Messages ---[/]")
+            for msg in messages:
+                # Extract role
+                if isinstance(msg, dict):
+                    role = msg.get('role', '')
+                    content = self._extract_content(msg)
+                else:
+                    role = getattr(msg, 'role', '')
+                    content = self._extract_content(msg)
+
+                # Only show user and agent messages, skip tool calls
+                if role == 'user':
+                    chat_log.write(f"[cyan]you:[/] {content}")
+                elif role == 'assistant':
+                    chat_log.write(f"[green]agent:[/] {content}")
+
+            chat_log.write("[dim]--- End History ---[/]")
+            chat_log.write("")
+
+        except Exception as e:
+            chat_log.write(f"[yellow]Could not load message history: {e}[/]")
+            if self._debug:
+                import traceback
+                chat_log.write(f"[dim]{traceback.format_exc()}[/]")
+            chat_log.write("")
+        finally:
+            if client:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+
+    def _extract_content(self, msg) -> str:
+        """Extract text content from message (handles both dict and MessageInfo)."""
+        # MessageInfo has 'parts' field: [{'type': 'text', 'text': '...'}]
+        if isinstance(msg, dict):
+            parts = msg.get('parts', [])
+        else:
+            parts = getattr(msg, 'parts', [])
+
+        if parts:
+            # Extract text from parts (handle both dict and object)
+            texts = []
+            for p in parts:
+                # Check if part is a dict or object
+                if isinstance(p, dict):
+                    part_type = p.get('type')
+                    part_text = p.get('text', '')
+                else:
+                    part_type = getattr(p, 'type', None)
+                    part_text = getattr(p, 'text', '')
+
+                if part_type == 'text':
+                    texts.append(part_text)
+            return ' '.join(texts)
+
+        # Fallback: try content field
+        if isinstance(msg, dict):
+            return msg.get('content', '')
+        else:
+            return getattr(msg, 'content', '') or str(msg)
+
+    def _build_agent(self) -> None:
+        """Build the LangGraph agent."""
+        from nav_agent import build_agent
+
+        self._agent, self._checkpointer = build_agent()
+        self._thread_config = {
+            "configurable": {
+                "thread_id": self._session_id,
+                "actor_id": config.ACTOR_ID,
+                "assistant_id": config.ASSISTANT_ID,
+            }
+        }
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle user input submission."""
+        text = event.value.strip()
+        event.input.value = ""  # Clear input
+
+        if not text:
+            return
+
+        # Check for quit commands
+        if text.lower() in ("quit", "exit", "q"):
+            self.exit()
+            return
+
+        # Auto-set title on first message
+        if not self._title_auto_set:
+            self._title_auto_set = True
+            new_title = text[:30]
+            session_manager.update_session_title(self._session_id, new_title)
+            self._session_title = new_title
+
+        # Run agent in background worker
+        self.run_worker(self._send_message(text), exclusive=True)
+
+    async def _send_message(self, text: str) -> None:
+        """Send message to agent and display response."""
+        chat_log = self.query_one("#chat_log", RichLog)
+        input_widget = self.query_one("#user_input", Input)
+
+        # Disable input while processing
+        input_widget.disabled = True
+
+        try:
+            # Display user message
+            chat_log.write(f"[cyan]you:[/] {text}")
+
+            # Invoke agent in thread (avoid blocking TUI event loop)
+            result = await asyncio.to_thread(self._invoke_agent_sync, text)
+
+            # Display agent response
+            if "error" in result:
+                chat_log.write(f"[red]agent: {result['error']}[/]")
+            else:
+                reply = result.get("reply", "")
+                chat_log.write(f"[green]agent:[/] {reply}")
+
+            self._message_count += 1
+
+        except Exception as e:
+            chat_log.write(f"[red]Error: {str(e)}[/]")
+
+        finally:
+            # Re-enable input
+            input_widget.disabled = False
+            input_widget.focus()
+
+    def _invoke_agent_sync(self, text: str) -> dict:
+        """Synchronously invoke agent.
+
+        This runs in a worker thread via asyncio.to_thread().
+        """
+        from langchain_core.messages import HumanMessage
+
+        try:
+            result = self._agent.invoke(
+                {"messages": [HumanMessage(content=text)]},
+                config=self._thread_config,
+            )
+
+            # Extract reply from result
+            messages = result.get("messages", [])
+            if messages:
+                last_msg = messages[-1]
+                reply = last_msg.content if hasattr(last_msg, "content") else str(last_msg)
+                return {"reply": reply}
+            else:
+                return {"reply": "(no response)"}
+
+        except Exception as e:
+            return {"error": str(e)}
+
+    def action_clear_log(self) -> None:
+        """Clear the chat log."""
+        chat_log = self.query_one("#chat_log", RichLog)
+        chat_log.clear()
+
+    def on_unmount(self) -> None:
+        """Cleanup on app exit."""
+        if self._session_id and self._message_count > 0:
+            try:
+                session_manager.update_session(self._session_id, self._message_count)
+            except Exception:
+                pass
+
+        if self._checkpointer:
+            try:
+                self._checkpointer.close()
+            except Exception:
+                pass

--- a/examples/navigation_langgraph_memory/tui_app.py
+++ b/examples/navigation_langgraph_memory/tui_app.py
@@ -266,6 +266,7 @@ class NavAgentApp(App):
         self._debug = debug
         self._agent = None
         self._checkpointer = None
+        self._store = None
         self._thread_config = None
         self._session_id = None
         self._session_title = None
@@ -436,7 +437,7 @@ class NavAgentApp(App):
         """Build the LangGraph agent."""
         from nav_agent import build_agent
 
-        self._agent, self._checkpointer = build_agent()
+        self._agent, self._checkpointer, self._store = build_agent()
         self._thread_config = {
             "configurable": {
                 "thread_id": self._session_id,
@@ -541,5 +542,11 @@ class NavAgentApp(App):
         if self._checkpointer:
             try:
                 self._checkpointer.close()
+            except Exception:
+                pass
+
+        if self._store:
+            try:
+                self._store.close()
             except Exception:
                 pass

--- a/examples/navigation_langgraph_memory/tui_encoding.py
+++ b/examples/navigation_langgraph_memory/tui_encoding.py
@@ -1,0 +1,21 @@
+"""TUI encoding utilities for Windows compatibility."""
+import sys
+
+
+def ensure_utf8_streams():
+    """Ensure stdout/stderr use UTF-8 encoding for proper Chinese character display.
+
+    This is critical for Windows where the default console encoding might be GBK,
+    causing UnicodeEncodeError when printing Chinese characters.
+    """
+    if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+
+    if sys.stderr and hasattr(sys.stderr, "reconfigure"):
+        try:
+            sys.stderr.reconfigure(encoding="utf-8")
+        except Exception:
+            pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,11 @@ docs = [
     "sphinx-rtd-theme>=1.3.0",
     "myst-parser>=2.0.0",
 ]
+tui = [
+    "textual>=0.86.0",
+]
 all = [
-    "agentarts-sdk[web,langchain,langgraph,autogen,crewai,vector-stores,database,monitoring,huaweicloud,docs]",
+    "agentarts-sdk[web,langchain,langgraph,autogen,crewai,vector-stores,database,monitoring,huaweicloud,docs,tui]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Add a navigation agent demo (`examples/navigation_langgraph_memory/`) that showcases LangGraph ReAct agent + AgentArts Memory SDK integration in a realistic use case: an interactive POI search, route planning, and map navigation assistant with long-term memory recall.

Also adds `tui` extra to pyproject.toml and updates .gitignore for the new demo.

## Highlights

### Agent & Memory
- LangGraph agent with 5 tools: geocode, POI search, route planning (4 modes), map link generation, and semantic memory recall
- Conversation state persisted via `AgentArtsMemorySessionSaver` checkpointer; backend auto-extracts memories via semantic/episodic/user_preference/summary strategies
- `recall_memory` tool for cross-session long-term memory search

### UX
- **TUI mode** (default): Textual-based interface with session picker, chat history loading, and session rename
- **CLI mode** (`--cli`): classic terminal interaction with session manager
- **Multi-session**: create/resume/rename sessions; metadata stored in local `sessions.json`

### Developer experience
- Mock data fallback when `AMAP_KEY` is not set — full agent graph works without any real API keys (only LLM credentials required)
- `.env`-based configuration with SSL verification toggle for internal networks
- One-time `setup_memory.py` script creates the memory space and writes credentials to `.env`
- Bilingual README (EN/CN)

### Config changes
- `pyproject.toml`: add `tui` extra (`textual>=0.86.0`) and include it in `all`
- `.gitignore`: exclude `examples/navigation_langgraph_memory/sessions.json`

## How to test

```bash
uv sync --extra langgraph --extra tui
cp examples/navigation_langgraph_memory/.env.example examples/navigation_langgraph_memory/.env
# edit .env → fill OPENAI_API_KEY
uv run python examples/navigation_langgraph_memory/setup_memory.py
uv run python examples/navigation_langgraph_memory/nav_agent.py          # TUI
uv run python examples/navigation_langgraph_memory/nav_agent.py --cli    # CLI
```

- Mock mode works without AMAP_KEY — only LLM credentials needed
- Tested on Windows 11 with Chinese input/output