### PR TITLE
feat(memory): expose get_session to client layer

### DIFF
--- a/src/agentarts/sdk/memory/async_client.py
+++ b/src/agentarts/sdk/memory/async_client.py
@@ -196,6 +196,10 @@ class AsyncMemoryClient:
         """Delete a session (soft delete) - identical to sync version."""
         await self._async_data_plane.delete_session(space_id, session_id)
 
+    async def get_session(self, space_id: str, session_id: str) -> SessionInfo:
+        """Get session details - identical to sync version."""
+        return await self._async_data_plane.get_session(space_id, session_id)
+
     # ==================== Data Plane - Message Management (Async) ====================
 
     async def get_last_k_messages(

--- a/src/agentarts/sdk/memory/async_session.py
+++ b/src/agentarts/sdk/memory/async_session.py
@@ -18,6 +18,7 @@ from .inner.config import (
     MessageInfo,
     MessageListResponse,
     SessionCreateRequest,
+    SessionInfo,
     TextMessage,
     ToolCallMessage,
     ToolResultMessage,
@@ -135,6 +136,12 @@ class AsyncMemorySession:
         """Delete this session (soft delete) - identical to sync version."""
         await self._async_data_plane.delete_session(self.space_id, self.session_id)
         logger.info(f"Session deleted: {self.session_id} in space: {self.space_id}")
+
+    async def get_info(self) -> SessionInfo:
+        """Get details of this session - identical to sync version."""
+        await self._ensure_initialized()
+        logger.info(f"Getting session info: {self.session_id} in space: {self.space_id}")
+        return await self._async_data_plane.get_session(self.space_id, self.session_id)
 
     # ==================== Message Management (Async) ====================
 

--- a/src/agentarts/sdk/memory/client.py
+++ b/src/agentarts/sdk/memory/client.py
@@ -513,6 +513,22 @@ class MemoryClient:
         """
         self._data_plane.delete_session(space_id, session_id)
 
+    def get_session(self, space_id: str, session_id: str) -> SessionInfo:
+        """
+        Get session details.
+
+        Args:
+            space_id: Space ID
+            session_id: Session ID
+
+        Returns:
+            SessionInfo: Session details
+
+        Examples:
+            >>> session_info = client.get_session("space-123", "session-456")
+        """
+        return self._data_plane.get_session(space_id, session_id)
+
     # ==================== Data Plane - Message Management ====================
 
     def get_last_k_messages(

--- a/src/agentarts/sdk/memory/inner/dataplane.py
+++ b/src/agentarts/sdk/memory/inner/dataplane.py
@@ -115,6 +115,28 @@ class _DataPlane:
         self.client.delete_session(space_id, session_id)
         logger.info(f"Session deleted: {session_id} in space: {space_id}")
 
+    def get_session(self, space_id: str, session_id: str) -> SessionInfo:
+        """
+        Get session details.
+
+        Args:
+            space_id: Space ID
+            session_id: Session ID
+
+        Returns:
+            SessionInfo: Session details
+        """
+        if not space_id:
+            msg = "space_id is required for data plane operations"
+            raise ValueError(msg)
+        if not session_id:
+            msg = "session_id is required for get_session"
+            raise ValueError(msg)
+
+        result = self.client.get_session(space_id, session_id)
+        logger.info(f"Session retrieved: {session_id} in space: {space_id}")
+        return SessionInfo.from_dict(result)
+
     def add_messages(
             self,
             space_id: str,

--- a/src/agentarts/sdk/memory/inner/dataplane_async.py
+++ b/src/agentarts/sdk/memory/inner/dataplane_async.py
@@ -103,6 +103,19 @@ class _AsyncDataPlane:
         await self.client.delete_session(space_id, session_id)
         logger.info(f"Session deleted: {session_id} in space: {space_id}")
 
+    async def get_session(self, space_id: str, session_id: str) -> SessionInfo:
+        """Get session details - identical to sync version."""
+        if not space_id:
+            msg = "space_id is required for data plane operations"
+            raise ValueError(msg)
+        if not session_id:
+            msg = "session_id is required for get_session"
+            raise ValueError(msg)
+
+        result = await self.client.get_session(space_id, session_id)
+        logger.info(f"Session retrieved: {session_id} in space: {space_id}")
+        return SessionInfo.from_dict(result)
+
     async def add_messages(
             self,
             space_id: str,

--- a/src/agentarts/sdk/memory/session.py
+++ b/src/agentarts/sdk/memory/session.py
@@ -15,6 +15,7 @@ from .inner.config import (
     MessageInfo,
     MessageListResponse,
     SessionCreateRequest,
+    SessionInfo,
     TextMessage,
     ToolCallMessage,
     ToolResultMessage,
@@ -214,6 +215,16 @@ class MemorySession:
         """
         self._data_plane.delete_session(self.space_id, self.session_id)
         logger.info(f"Session deleted: {self.session_id} in space: {self.space_id}")
+
+    def get_info(self) -> SessionInfo:
+        """
+        Get details of this session.
+
+        Returns:
+            SessionInfo: Session details including id, space_id, actor_id, etc.
+        """
+        logger.info(f"Getting session info: {self.session_id} in space: {self.space_id}")
+        return self._data_plane.get_session(self.space_id, self.session_id)
 
     # ==================== Message Management ====================
 


### PR DESCRIPTION
### Summary

- Expose `get_session` from the HTTP service layer through to the dataplane and client layers, for both sync and async variants
- Add `get_info()` convenience method to `MemorySession` and `AsyncMemorySession` that retrieves `SessionInfo` for the current session
- Dataplane layer parses the raw `dict` response into `SessionInfo` via `from_dict()`, consistent with `create_memory_session`
- Async `get_info()` calls `_ensure_initialized()` before querying, matching the pattern of other async session methods

### Changed Files

| File | Changes |
|------|---------|
| `src/agentarts/sdk/memory/inner/dataplane.py` | Add `get_session()` with space_id/session_id validation, returns `SessionInfo` |
| `src/agentarts/sdk/memory/inner/dataplane_async.py` | Add async `get_session()`, identical to sync version |
| `src/agentarts/sdk/memory/client.py` | Expose `get_session()` in `MemoryClient`, returns `SessionInfo` |
| `src/agentarts/sdk/memory/async_client.py` | Expose `get_session()` in `AsyncMemoryClient` |
| `src/agentarts/sdk/memory/session.py` | Add `get_info()` convenience method; import `SessionInfo` |
| `src/agentarts/sdk/memory/async_session.py` | Add `get_info()` convenience method; import `SessionInfo` |

### Verification

The get_session API was verified across all three access layers using a test script that creates a session, queries it via the new get_session or get_info method, and asserts the returned SessionInfo fields match the created session. MemoryClient.get_session() successfully retrieves SessionInfo with matching id, space_id, actor_id, and created_at fields. MemorySession.get_info() produces identical results through the convenience method. AsyncMemoryClient.get_session() and AsyncMemorySession.get_info() both complete without error, confirming that the async path correctly calls _ensure_initialized before querying and that the dataplane layer properly parses the raw dict response into SessionInfo via from_dict. All assertions pass, confirming end-to-end propagation from service layer through dataplane to client and session.
