### PR TITLE
feat(memory): add list_sessions API support

### DIFF
--- a/src/agentarts/sdk/memory/async_client.py
+++ b/src/agentarts/sdk/memory/async_client.py
@@ -23,6 +23,7 @@ from .inner.config import (
     MessageListResponse,
     SessionCreateRequest,
     SessionInfo,
+    SessionListResponse,
     SpaceCreateRequest,
     SpaceInfo,
     SpaceListResponse,
@@ -191,6 +192,11 @@ class AsyncMemoryClient:
         )
 
         return await self._async_data_plane.create_memory_session(space_id, session_request)
+
+    async def list_sessions(self, space_id: str, actor_id: str | None = None,
+                            limit: int = 20, offset: int = 0) -> SessionListResponse:
+        """List sessions in a space - identical to sync version."""
+        return await self._async_data_plane.list_sessions(space_id, actor_id, limit, offset)
 
     async def delete_session(self, space_id: str, session_id: str) -> None:
         """Delete a session (soft delete) - identical to sync version."""

--- a/src/agentarts/sdk/memory/client.py
+++ b/src/agentarts/sdk/memory/client.py
@@ -20,6 +20,7 @@ from .inner.config import (
     MessageListResponse,
     SessionCreateRequest,
     SessionInfo,
+    SessionListResponse,
     SpaceCreateRequest,
     SpaceInfo,
     SpaceListResponse,
@@ -496,6 +497,26 @@ class MemoryClient:
         )
 
         return self._data_plane.create_memory_session(space_id, session_request)
+
+    def list_sessions(self, space_id: str, actor_id: str | None = None,
+                      limit: int = 20, offset: int = 0) -> SessionListResponse:
+        """
+        List sessions in a space.
+
+        Args:
+            space_id: Space ID
+            actor_id: Filter by Actor ID (optional)
+            limit: Page size (1-20, default 20)
+            offset: Pagination offset (default 0)
+
+        Returns:
+            SessionListResponse: Paginated session list
+
+        Examples:
+            >>> sessions = client.list_sessions("space-123")
+            >>> sessions = client.list_sessions("space-123", actor_id="user-456")
+        """
+        return self._data_plane.list_sessions(space_id, actor_id, limit, offset)
 
     def delete_session(self, space_id: str, session_id: str) -> None:
         """

--- a/src/agentarts/sdk/memory/inner/dataplane.py
+++ b/src/agentarts/sdk/memory/inner/dataplane.py
@@ -32,6 +32,7 @@ from .config import (
     MessageListResponse,
     SessionCreateRequest,
     SessionInfo,
+    SessionListResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,34 @@ class _DataPlane:
 
         logger.info(f"Memory session created: {result.get('id')}")
         return SessionInfo.from_dict(result)
+
+    def list_sessions(self, space_id: str, actor_id: str | None = None,
+                      limit: int = 20, offset: int = 0) -> SessionListResponse:
+        """
+        List sessions in a space.
+
+        Args:
+            space_id: Space ID
+            actor_id: Filter by Actor ID (optional)
+            limit: Page size (1-20, default 20)
+            offset: Pagination offset (default 0)
+
+        Returns:
+            SessionListResponse: Paginated session list
+        """
+        if not space_id:
+            msg = "space_id is required for data plane operations"
+            raise ValueError(msg)
+
+        logger.info(f"Listing sessions in space: {space_id}")
+        result = self.client.list_sessions(
+            space_id,
+            actor_id=actor_id,
+            limit=limit,
+            offset=offset
+        )
+        logger.info(f"Sessions retrieved: {len(result.get('items', []))} sessions")
+        return SessionListResponse.from_dict(result)
 
     def delete_session(self, space_id: str, session_id: str) -> None:
         """

--- a/src/agentarts/sdk/memory/inner/dataplane_async.py
+++ b/src/agentarts/sdk/memory/inner/dataplane_async.py
@@ -23,6 +23,7 @@ from .config import (
     MessageListResponse,
     SessionCreateRequest,
     SessionInfo,
+    SessionListResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,23 @@ class _AsyncDataPlane:
 
         logger.info(f"Memory session created: {result.get('id')}")
         return SessionInfo.from_dict(result)
+
+    async def list_sessions(self, space_id: str, actor_id: str | None = None,
+                            limit: int = 20, offset: int = 0) -> SessionListResponse:
+        """List sessions in a space - identical to sync version."""
+        if not space_id:
+            msg = "space_id is required for data plane operations"
+            raise ValueError(msg)
+
+        logger.info(f"Listing sessions in space: {space_id}")
+        result = await self.client.list_sessions(
+            space_id,
+            actor_id=actor_id,
+            limit=limit,
+            offset=offset
+        )
+        logger.info(f"Sessions retrieved: {len(result.get('items', []))} sessions")
+        return SessionListResponse.from_dict(result)
 
     async def delete_session(self, space_id: str, session_id: str) -> None:
         """

--- a/src/agentarts/sdk/service/memory_service.py
+++ b/src/agentarts/sdk/service/memory_service.py
@@ -445,6 +445,34 @@ class MemoryHttpService:
             space_id=space_id
         )
 
+    def list_sessions(self, space_id: str, actor_id: str | None = None,
+                      limit: int | None = None, offset: int | None = None) -> dict[str, Any]:
+        """List sessions in a space.
+
+        Args:
+            space_id: Space ID
+            actor_id: Filter by Actor ID (optional)
+            limit: Page size (1-20, default 20)
+            offset: Pagination offset (default 0)
+
+        Returns:
+            dict containing items, total, limit, offset
+        """
+        params = {}
+        if actor_id is not None:
+            params["actor_id"] = actor_id
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        return self._make_request(
+            method="GET",
+            path=f"/v1/core/spaces/{space_id}/sessions",
+            params=params,
+            space_id=space_id
+        )
+
     def get_session(self, space_id: str, session_id: str) -> dict[str, Any]:
         """Get session information.
 

--- a/src/agentarts/sdk/service/memory_service_async.py
+++ b/src/agentarts/sdk/service/memory_service_async.py
@@ -351,6 +351,24 @@ class AsyncMemoryHttpService:
             space_id=space_id
         )
 
+    async def list_sessions(self, space_id: str, actor_id: str | None = None,
+                            limit: int | None = None, offset: int | None = None) -> dict[str, Any]:
+        """List sessions in a space - identical to sync version."""
+        params = {}
+        if actor_id is not None:
+            params["actor_id"] = actor_id
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        return await self._make_request(
+            method="GET",
+            path=f"/v1/core/spaces/{space_id}/sessions",
+            params=params,
+            space_id=space_id
+        )
+
     async def get_session(self, space_id: str, session_id: str) -> dict[str, Any]:
         """Get session information - identical to sync version."""
         return await self._make_request(


### PR DESCRIPTION
### Summary

- Add `list_sessions` API across service, dataplane, and client layers for both sync and async variants
- Supports pagination via `limit` and `offset` parameters
- Supports optional `actor_id` filter to narrow results by participant
- Reuses existing `SessionListResponse` and `SessionInfo` dataclasses from `memory/inner/config.py` — no new dataclass needed

### Changed Files

| File | Changes |
|------|---------|
| `src/agentarts/sdk/service/memory_service.py` | Add `list_sessions()` with query param building |
| `src/agentarts/sdk/service/memory_service_async.py` | Add async `list_sessions()` |
| `src/agentarts/sdk/memory/inner/dataplane.py` | Add `list_sessions()` returning `SessionListResponse`; import `SessionListResponse` |
| `src/agentarts/sdk/memory/inner/dataplane_async.py` | Add async `list_sessions()` returning `SessionListResponse`; import `SessionListResponse` |
| `src/agentarts/sdk/memory/client.py` | Expose `list_sessions()` in `MemoryClient`; import `SessionListResponse` |
| `src/agentarts/sdk/memory/async_client.py` | Expose `list_sessions()` in `AsyncMemoryClient`; import `SessionListResponse` |

### Verification

The list_sessions API was verified using a test script that creates multiple sessions in a shared Space and then queries them via the new list_sessions method. The test confirms that the returned SessionListResponse contains the expected sessions with matching id, space_id, and actor_id fields. Pagination is validated by creating more sessions than the default limit and verifying that the total field reflects the correct count while items respects the limit parameter. The optional actor_id filter is tested by creating sessions with different actors and confirming that filtering returns only the matching subset. Both sync (MemoryClient) and async (AsyncMemoryClient) paths produce consistent results, confirming end-to-end propagation from service layer through dataplane to client.
