### PR TITLE
fix(integration/langgraph): use TextMessage in _handle_put and fix to_dict() output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize line endings: store LF in the repository, convert to native
+# (CRLF on Windows) on checkout. See https://git-scm.com/docs/gitattributes
+* text=auto

--- a/src/agentarts/sdk/integration/langgraph/store.py
+++ b/src/agentarts/sdk/integration/langgraph/store.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from agentarts.sdk.memory import AsyncMemoryClient, MemoryClient
-from agentarts.sdk.memory.inner.config import MemorySearchFilter
+from agentarts.sdk.memory.inner.config import MemorySearchFilter, TextMessage
 from agentarts.sdk.utils.constant import get_region
 
 logger = logging.getLogger(__name__)
@@ -255,26 +255,24 @@ class AgentArtsMemoryStore(BaseStore):
         actor_id = op.value.get("actor_id")
         assistant_id = op.value.get("assistant_id")
 
-        message_data = {
-            "role": "user",
-            "parts": [{"type": "text", "text": content}],
-        }
-        if actor_id:
-            message_data["actor_id"] = actor_id
-        if assistant_id:
-            message_data["assistant_id"] = assistant_id
-
         meta = {
             "store_key": op.key,
             "store_namespace": list(op.namespace),
         }
-        message_data["meta"] = json.dumps(meta, ensure_ascii=False)
+
+        message = TextMessage(
+            role="user",
+            content=content,
+            actor_id=actor_id,
+            assistant_id=assistant_id,
+            meta=json.dumps(meta, ensure_ascii=False),
+        )
 
         try:
             self._client.add_messages(
                 space_id=self._space_id,
                 session_id=session_id,
-                messages=[message_data],
+                messages=[message],
             )
             logger.debug(f"Added message to session {session_id} for namespace {op.namespace}")
 
@@ -303,26 +301,24 @@ class AgentArtsMemoryStore(BaseStore):
         actor_id = op.value.get("actor_id")
         assistant_id = op.value.get("assistant_id")
 
-        message_data = {
-            "role": "user",
-            "parts": [{"type": "text", "text": content}],
-        }
-        if actor_id:
-            message_data["actor_id"] = actor_id
-        if assistant_id:
-            message_data["assistant_id"] = assistant_id
-
         meta = {
             "store_key": op.key,
             "store_namespace": list(op.namespace),
         }
-        message_data["meta"] = json.dumps(meta, ensure_ascii=False)
+
+        message = TextMessage(
+            role="user",
+            content=content,
+            actor_id=actor_id,
+            assistant_id=assistant_id,
+            meta=json.dumps(meta, ensure_ascii=False),
+        )
 
         try:
             await self._async_client.add_messages(
                 space_id=self._space_id,
                 session_id=session_id,
-                messages=[message_data],
+                messages=[message],
             )
             logger.debug(f"Added message to session {session_id} for namespace {op.namespace}")
 

--- a/src/agentarts/sdk/memory/inner/config.py
+++ b/src/agentarts/sdk/memory/inner/config.py
@@ -918,6 +918,10 @@ class TextMessage:
             "role": self.role,
             "parts": [{"type": "text", "text": self.content}]
         }
+        if self.actor_id is not None:
+            result["actor_id"] = self.actor_id
+        if self.assistant_id is not None:
+            result["assistant_id"] = self.assistant_id
         if self.meta:
             result["meta"] = self.meta
         return result

--- a/tests/unit/sdk/integration/test_langgraph_store.py
+++ b/tests/unit/sdk/integration/test_langgraph_store.py
@@ -9,6 +9,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -103,10 +104,11 @@ class TestAgentArtsMemoryStorePut:
                         store._handle_put(op)
 
     def test_put_calls_add_messages(self):
-        """Test that Put calls add_messages with correct params"""
+        """Test that Put constructs TextMessage (not raw dict) and calls add_messages."""
         from langgraph.store.base import PutOp
 
         from agentarts.sdk.integration.langgraph.store import AgentArtsMemoryStore
+        from agentarts.sdk.memory.inner.config import TextMessage
 
         with patch("agentarts.sdk.integration.langgraph.store.LANGGRAPH_AVAILABLE", True):
             with patch("agentarts.sdk.integration.langgraph.store.MemoryClient") as mock_client_cls:
@@ -135,8 +137,18 @@ class TestAgentArtsMemoryStorePut:
                     assert call_args.kwargs["session_id"] == "session-123"
                     messages = call_args.kwargs["messages"]
                     assert len(messages) == 1
-                    assert messages[0]["role"] == "user"
-                    assert messages[0]["actor_id"] == "user-001"
+                    # message must be TextMessage instance, not raw dict
+                    assert isinstance(messages[0], TextMessage)
+                    # Verify to_dict() outputs actor_id (was missing before fix)
+                    msg_dict = messages[0].to_dict()
+                    assert msg_dict["role"] == "user"
+                    assert msg_dict["actor_id"] == "user-001"
+                    assert "parts" in msg_dict
+                    # Verify meta contains store_key and store_namespace
+                    assert msg_dict["meta"] is not None
+                    meta = json.loads(msg_dict["meta"])
+                    assert meta["store_key"] == "msg-1"
+                    assert meta["store_namespace"] == ["memories", "user-001"]
 
     def test_put_delete_not_supported(self):
         """Test that delete (value=None) is not supported"""
@@ -161,6 +173,31 @@ class TestAgentArtsMemoryStorePut:
                     store._handle_put(op)
 
                     mock_client.add_messages.assert_not_called()
+
+    def test_put_swallows_exception(self):
+        """Test that Put swallows exceptions (default behavior, opt-in re-raise planned)."""
+        from langgraph.store.base import PutOp
+
+        from agentarts.sdk.integration.langgraph.store import AgentArtsMemoryStore
+
+        with patch("agentarts.sdk.integration.langgraph.store.LANGGRAPH_AVAILABLE", True):
+            with patch("agentarts.sdk.integration.langgraph.store.MemoryClient") as mock_client_cls:
+                with patch("agentarts.sdk.integration.langgraph.store.AsyncMemoryClient"):
+                    mock_client = MagicMock()
+                    mock_client.add_messages.side_effect = RuntimeError("network error")
+                    mock_client_cls.return_value = mock_client
+
+                    store = AgentArtsMemoryStore(space_id="test-space")
+
+                    op = PutOp(
+                        namespace=("memories",),
+                        key="msg-1",
+                        value={"content": "test", "session_id": "s1"},
+                    )
+
+                    # Should not raise, should return None
+                    result = store._handle_put(op)
+                    assert result is None
 
 
 class TestAgentArtsMemoryStoreSearch:


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in `AgentArtsMemoryStore._handle_put()` and `_async_handle_put()` where messages were being constructed as raw dictionaries instead of `TextMessage` instances, causing `MemoryClient.add_messages()` to reject them with a `ValueError` due to type validation. The fix also addresses a serialization bug in `TextMessage.to_dict()` that was silently dropping `actor_id` and `assistant_id` fields.

Additionally, this PR adds a `.gitattributes` file to normalize line endings across platforms, preventing false "modified" status caused by CRLF/LF mismatches in the working tree.

## Changes

### Bug Fixes

**`src/agentarts/sdk/memory/inner/config.py`**

Fixed `TextMessage.to_dict()` to include `actor_id` and `assistant_id` fields in the output dictionary when they are not None. Previously, the method only serialized `role`, `parts`, and `meta`, causing these fields to be lost when messages were converted to the OpenAPI format expected by the backend API.

**`src/agentarts/sdk/integration/langgraph/store.py`**

Replaced raw dictionary construction in `_handle_put()` and `_async_handle_put()` with proper `TextMessage` dataclass instantiation. The previous implementation built a plain dict with manually assembled fields, which failed the `isinstance(msg, (TextMessage, ToolCallMessage, ToolResultMessage))` type check in `MemoryClient.add_messages()`. The new implementation uses `TextMessage` directly, ensuring type safety and proper field serialization through the fixed `to_dict()` method. The exception handling behavior (swallowing exceptions and returning None) is preserved for backward compatibility, with an opt-in re-raise mechanism planned for a future release.

### Test Updates

**`tests/unit/sdk/integration/test_langgraph_store.py`**

Updated `test_put_calls_add_messages()` to verify that messages are `TextMessage` instances (not raw dicts), that `to_dict()` correctly outputs `actor_id`, and that the `meta` field contains the expected `store_key` and `store_namespace` values. Added `test_put_swallows_exception()` to document and verify the current exception handling behavior where errors are logged but not re-raised.

### Infrastructure

**`.gitattributes`**

Added `.gitattributes` with `* text=auto` to ensure text files are stored with LF line endings in the repository while being converted to the platform-native line ending (CRLF on Windows) on checkout. This prevents widespread false "modified" status in `git status` output caused by line ending mismatches between the working tree and the repository.

## Verification

All 28 unit tests in `tests/unit/sdk/integration/test_langgraph_store.py` pass successfully. The test suite covers the complete `AgentArtsMemoryStore` API surface including put operations, search operations, get operations, delete operations, namespace listing, and async variants. Manual testing was performed using a demo script that verified `TextMessage.to_dict()` now outputs `actor_id` and `assistant_id`, and that `store.put()` successfully adds messages without raising type validation errors.
