### PR TITLE
fix(integration/langgraph): make actor_id and assistant_id truly optional in CheckpointerConfig

### DIFF
--- a/src/agentarts/sdk/integration/langgraph/config.py
+++ b/src/agentarts/sdk/integration/langgraph/config.py
@@ -44,8 +44,8 @@ class CheckpointerConfig(BaseModel):
     """
 
     thread_id: str
-    actor_id: str = ""
-    assistant_id: str = ""
+    actor_id: str | None = None
+    assistant_id: str | None = None
     checkpoint_ns: str | None = None
     checkpoint_id: str | None = None
 
@@ -75,8 +75,8 @@ class CheckpointerConfig(BaseModel):
 
         return cls(
             thread_id=thread_id,
-            actor_id=configurable.get("actor_id", ""),
-            assistant_id=configurable.get("assistant_id", ""),
+            actor_id=configurable.get("actor_id"),
+            assistant_id=configurable.get("assistant_id"),
             checkpoint_ns=configurable.get("checkpoint_ns"),
             checkpoint_id=configurable.get("checkpoint_id"),
         )


### PR DESCRIPTION
### Problem

When using the LangGraph checkpointer integration with only `thread_id` in `RunnableConfig` (the only field LangGraph requires), the SDK would silently inject empty strings for `actor_id` and `assistant_id`. These empty strings were then serialized into the request body sent to the backend, which rejects them with HTTP 400 because the `actorId` field has a length constraint of 1-64 characters.

Users following the LangGraph convention of providing only `thread_id` would see unexpected validation errors, even though they correctly used the API as documented.

### Root Cause

`CheckpointerConfig` defined `actor_id: str = ""` and `assistant_id: str = ""` as defaults, and `from_runnable_config` used `configurable.get("actor_id", "")` — both producing empty strings when the fields were not provided. Downstream, `TextMessage.to_dict()` uses `if self.actor_id is not None` to decide whether to include the field in the serialized output. Since `""` is not `None`, the empty strings passed through and appeared in the final request body as `"actorId": ""`.

### Fix

Changed the default values from `""` to `None` in both the field definitions and `from_runnable_config`. With `None` as the default, `TextMessage.to_dict()` correctly skips the field entirely when it is not provided, and the backend never receives it.

### Verification

All 23 existing unit tests in `tests/unit/sdk/integration/test_langgraph.py` continue to pass. A dedicated demo script was run to verify the fix across the full data flow: CheckpointerConfig defaults resolve to `None` rather than empty strings, `from_runnable_config` does not inject empty strings when fields are absent, explicitly provided values are still preserved correctly, `to_runnable_config` excludes `None` fields, and the end-to-end path from `RunnableConfig` through `CheckpointerConfig` to `TextMessage.to_dict()` produces a serialized message with no spurious empty-string fields. The script also includes a comparison test demonstrating that the old `""` default would have been serialized into the request body, confirming the root cause of the original backend validation failure.
