### PR TITLE
feat(integration/langgraph): preserve additional_kwargs and response_metadata in converter

### DIFF
--- a/src/agentarts/sdk/integration/langgraph/converter.py
+++ b/src/agentarts/sdk/integration/langgraph/converter.py
@@ -33,6 +33,55 @@ except ImportError:
     FunctionMessage = None
 
 
+def _parse_meta(meta: str | dict | None) -> dict:
+    """Parse meta from backend response.
+
+    Handles both str (JSON string) and dict (already parsed) formats.
+    Returns empty dict if meta is None or unparseable.
+    """
+    if not meta:
+        return {}
+    if isinstance(meta, dict):
+        return dict(meta)
+    if isinstance(meta, str):
+        try:
+            result = json.loads(meta)
+            return result if isinstance(result, dict) else {}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return {}
+
+
+def _build_meta(
+    caller_meta: str | None,
+    additional_kwargs: dict | None = None,
+    response_metadata: dict | None = None,
+    extra: dict | None = None,
+) -> str | None:
+    """Merge caller's meta with LangChain-specific fields.
+
+    Args:
+        caller_meta: JSON string from caller (e.g., saver's checkpoint_meta)
+        additional_kwargs: LangChain message's additional_kwargs
+        response_metadata: LangChain message's response_metadata
+        extra: Additional key-value pairs to merge (e.g., _lc_content)
+
+    Returns:
+        Merged JSON string, or None if nothing to store.
+    """
+    merged = _parse_meta(caller_meta)
+
+    if additional_kwargs:
+        merged["_lc_additional_kwargs"] = additional_kwargs
+    if response_metadata:
+        merged["_lc_response_metadata"] = response_metadata
+    if extra:
+        merged.update(extra)
+
+    # NOTE: non-JSON-serializable metadata (e.g. datetime/custom objects) is not handled and may raise TypeError here.
+    return json.dumps(merged, ensure_ascii=False) if merged else caller_meta
+
+
 def langgraph_to_memory_message(
     message: BaseMessage,
     actor_id: str | None = None,
@@ -72,52 +121,85 @@ def langgraph_to_memory_message(
         )
 
     if isinstance(message, HumanMessage):
+        merged_meta = _build_meta(
+            meta,
+            additional_kwargs=getattr(message, "additional_kwargs", None),
+        )
         return TextMessage(
             role="user",
             content=message.content,
             actor_id=actor_id,
             assistant_id=assistant_id,
-            meta=meta,
+            meta=merged_meta,
         )
 
     if isinstance(message, AIMessage):
         if hasattr(message, "tool_calls") and message.tool_calls:
+            extra = {}
+            if message.content:
+                extra["_lc_content"] = message.content
+
+            merged_meta = _build_meta(
+                meta,
+                additional_kwargs=getattr(message, "additional_kwargs", None),
+                response_metadata=getattr(message, "response_metadata", None),
+                extra=extra if extra else None,
+            )
+
             return ToolCallMessage(
                 id=message.tool_calls[0].get("id", ""),
                 name=message.tool_calls[0].get("name", ""),
                 arguments=json.dumps(message.tool_calls[0].get("args", {}), ensure_ascii=False),
-                meta=meta,
+                meta=merged_meta,
             )
+
+        merged_meta = _build_meta(
+            meta,
+            additional_kwargs=getattr(message, "additional_kwargs", None),
+            response_metadata=getattr(message, "response_metadata", None),
+        )
 
         return TextMessage(
             role="assistant",
             content=message.content,
             actor_id=actor_id,
             assistant_id=assistant_id,
-            meta=meta,
+            meta=merged_meta,
         )
 
     if isinstance(message, SystemMessage):
+        merged_meta = _build_meta(
+            meta,
+            additional_kwargs=getattr(message, "additional_kwargs", None),
+        )
         return TextMessage(
             role="system",
             content=message.content,
             actor_id=actor_id,
             assistant_id=assistant_id,
-            meta=meta,
+            meta=merged_meta,
         )
 
     if isinstance(message, ToolMessage):
+        merged_meta = _build_meta(
+            meta,
+            additional_kwargs=getattr(message, "additional_kwargs", None),
+        )
         return ToolResultMessage(
             tool_call_id=message.tool_call_id,
             content=str(message.content),
-            meta=meta,
+            meta=merged_meta,
         )
 
     if isinstance(message, FunctionMessage):
+        merged_meta = _build_meta(
+            meta,
+            additional_kwargs=getattr(message, "additional_kwargs", None),
+        )
         return ToolResultMessage(
             tool_call_id=message.name,
             content=str(message.content),
-            meta=meta,
+            meta=merged_meta,
         )
     if isinstance(message, ChatMessage):
         role = message.role
@@ -128,19 +210,27 @@ def langgraph_to_memory_message(
                 role = "user"
             else:
                 role = "user"
+        merged_meta = _build_meta(
+            meta,
+            additional_kwargs=getattr(message, "additional_kwargs", None),
+        )
         return TextMessage(
             role=role,
             content=str(message.content),
             actor_id=actor_id,
             assistant_id=assistant_id,
-            meta=meta,
+            meta=merged_meta,
         )
+    merged_meta = _build_meta(
+        meta,
+        additional_kwargs=getattr(message, "additional_kwargs", None),
+    )
     return TextMessage(
         role="user",
         content=str(message.content),
         actor_id=actor_id,
         assistant_id=assistant_id,
-        meta=meta,
+        meta=merged_meta,
     )
 
 
@@ -177,6 +267,12 @@ def memory_to_langgraph_message(
     role = message.role
     parts = message.parts or []
 
+    # Parse meta to extract LangChain-specific fields
+    meta_dict = _parse_meta(getattr(message, "meta", None))
+    additional_kwargs = meta_dict.get("_lc_additional_kwargs", {})
+    response_metadata = meta_dict.get("_lc_response_metadata", {})
+    preserved_content = meta_dict.get("_lc_content")
+
     text_content = ""
     tool_call_data = None
     tool_result_data = None
@@ -196,30 +292,48 @@ def memory_to_langgraph_message(
         return ToolMessage(
             content=tool_result_data.get("content", ""),
             tool_call_id=tool_result_data.get("tool_call_id", ""),
+            additional_kwargs=additional_kwargs,
         )
 
     if tool_call_data:
+        content = preserved_content if preserved_content is not None else text_content
         return AIMessage(
-            content=text_content,
+            content=content,
             tool_calls=[{
                 "id": tool_call_data.get("id", ""),
                 "name": tool_call_data.get("name", ""),
                 "args": json.loads(tool_call_data.get("arguments", "{}")),
             }],
+            additional_kwargs=additional_kwargs,
+            response_metadata=response_metadata,
         )
 
     if role == "user":
-        return HumanMessage(content=text_content)
+        return HumanMessage(
+            content=text_content,
+            additional_kwargs=additional_kwargs,
+        )
     if role == "assistant":
-        return AIMessage(content=text_content)
+        return AIMessage(
+            content=text_content,
+            additional_kwargs=additional_kwargs,
+            response_metadata=response_metadata,
+        )
     if role == "system":
-        return SystemMessage(content=text_content)
+        return SystemMessage(
+            content=text_content,
+            additional_kwargs=additional_kwargs,
+        )
     if role == "tool":
         return ToolMessage(
             content=text_content,
             tool_call_id="",
+            additional_kwargs=additional_kwargs,
         )
-    return HumanMessage(content=text_content)
+    return HumanMessage(
+        content=text_content,
+        additional_kwargs=additional_kwargs,
+    )
 
 
 def langgraph_messages_to_memory(

--- a/tests/unit/sdk/integration/test_langgraph.py
+++ b/tests/unit/sdk/integration/test_langgraph.py
@@ -245,6 +245,456 @@ class TestMessageMetaField:
         assert "meta" not in result
 
 
+class TestAdditionalKwargsPreservation:
+    """Tests for additional_kwargs / response_metadata preservation in converter."""
+
+    # --- _parse_meta helper ---
+
+    def test_parse_meta_none(self):
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta(None) == {}
+
+    def test_parse_meta_empty_string(self):
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta("") == {}
+
+    def test_parse_meta_json_string(self):
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta('{"step":1}') == {"step": 1}
+
+    def test_parse_meta_empty_json_string(self):
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta("{}") == {}
+
+    def test_parse_meta_dict(self):
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta({"step": 1}) == {"step": 1}
+
+    def test_parse_meta_non_json_string(self):
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta("not json") == {}
+
+    def test_parse_meta_json_array_string(self):
+        """JSON array is valid JSON but not a dict -- should return {}."""
+        from agentarts.sdk.integration.langgraph.converter import _parse_meta
+
+        assert _parse_meta("[1, 2, 3]") == {}
+
+    # --- _build_meta helper ---
+
+    def test_build_meta_none_caller_no_kwargs(self):
+        from agentarts.sdk.integration.langgraph.converter import _build_meta
+
+        assert _build_meta(None) is None
+
+    def test_build_meta_caller_only(self):
+        """Caller meta without LangChain fields is re-serialized unchanged."""
+        import json
+
+        from agentarts.sdk.integration.langgraph.converter import _build_meta
+
+        result = _build_meta('{"step":1}')
+        assert json.loads(result) == {"step": 1}
+
+    def test_build_meta_with_additional_kwargs(self):
+        import json
+
+        from agentarts.sdk.integration.langgraph.converter import _build_meta
+
+        result = _build_meta(
+            '{"step":1}',
+            additional_kwargs={"reasoning_content": "thinking"},
+        )
+        parsed = json.loads(result)
+        assert parsed["step"] == 1
+        assert parsed["_lc_additional_kwargs"] == {"reasoning_content": "thinking"}
+
+    def test_build_meta_with_response_metadata(self):
+        import json
+
+        from agentarts.sdk.integration.langgraph.converter import _build_meta
+
+        result = _build_meta(
+            None,
+            response_metadata={"model_name": "deepseek-v3.2"},
+        )
+        parsed = json.loads(result)
+        assert parsed["_lc_response_metadata"] == {"model_name": "deepseek-v3.2"}
+
+    def test_build_meta_with_extra(self):
+        import json
+
+        from agentarts.sdk.integration.langgraph.converter import _build_meta
+
+        result = _build_meta(
+            None,
+            extra={"_lc_content": "some text"},
+        )
+        parsed = json.loads(result)
+        assert parsed["_lc_content"] == "some text"
+
+    def test_build_meta_empty_additional_kwargs_not_stored(self):
+        """Empty dict additional_kwargs should not be stored (falsy)."""
+        import json
+
+        from agentarts.sdk.integration.langgraph.converter import _build_meta
+
+        result = _build_meta('{"step":1}', additional_kwargs={})
+        parsed = json.loads(result)
+        assert "_lc_additional_kwargs" not in parsed
+
+    # --- AIMessage round-trip ---
+
+    def test_ai_message_round_trip_additional_kwargs(self):
+        """AIMessage with reasoning_content survives a full round-trip."""
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import (
+            langgraph_to_memory_message,
+            memory_to_langgraph_message,
+        )
+        from agentarts.sdk.memory import MessageInfo
+
+        original = AIMessage(
+            content="Hello",
+            additional_kwargs={"reasoning_content": "user is greeting"},
+        )
+        mem_msg = langgraph_to_memory_message(original, meta='{"step":1}')
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="assistant",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=mem_msg.meta,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "Hello"
+        assert restored.additional_kwargs == {"reasoning_content": "user is greeting"}
+
+    def test_ai_message_round_trip_response_metadata(self):
+        """AIMessage response_metadata (model_name, finish_reason) survives round-trip."""
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import (
+            langgraph_to_memory_message,
+            memory_to_langgraph_message,
+        )
+        from agentarts.sdk.memory import MessageInfo
+
+        original = AIMessage(
+            content="Answer",
+            response_metadata={"model_name": "deepseek-v3.2", "finish_reason": "stop"},
+        )
+        mem_msg = langgraph_to_memory_message(original)
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="assistant",
+            parts=[{"type": "text", "text": "Answer"}],
+            meta=mem_msg.meta,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.response_metadata == {"model_name": "deepseek-v3.2", "finish_reason": "stop"}
+
+    def test_ai_message_with_tool_calls_preserves_content(self):
+        """AIMessage with both text and tool_calls preserves content in _lc_content."""
+        import json
+
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import (
+            langgraph_to_memory_message,
+            memory_to_langgraph_message,
+        )
+        from agentarts.sdk.memory import MessageInfo
+
+        original = AIMessage(
+            content="Let me check the weather",
+            tool_calls=[{"id": "tc1", "name": "get_weather", "args": {"city": "Tokyo"}}],
+            additional_kwargs={"reasoning_content": "user wants weather"},
+        )
+        mem_msg = langgraph_to_memory_message(original, meta='{"step":2}')
+
+        # Verify content stored in meta
+        parsed = json.loads(mem_msg.meta)
+        assert parsed["_lc_content"] == "Let me check the weather"
+
+        # Simulate backend round-trip
+        msg_info = MessageInfo(
+            id="2", session_id="s1", seq=1, role="tool",
+            parts=[{
+                "type": "tool_call",
+                "tool_call": {
+                    "id": "tc1",
+                    "name": "get_weather",
+                    "arguments": json.dumps({"city": "Tokyo"}),
+                },
+            }],
+            meta=mem_msg.meta,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "Let me check the weather"
+        assert restored.additional_kwargs == {"reasoning_content": "user wants weather"}
+        assert restored.tool_calls[0]["name"] == "get_weather"
+
+    def test_ai_message_with_tool_calls_no_content(self):
+        """AIMessage with tool_calls but empty content -- _lc_content not stored."""
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import langgraph_to_memory_message
+
+        original = AIMessage(
+            content="",
+            tool_calls=[{"id": "tc1", "name": "search", "args": {"q": "test"}}],
+        )
+        mem_msg = langgraph_to_memory_message(original)
+
+        # No content, no additional_kwargs, no response_metadata, no caller_meta
+        # -> _build_meta returns None (nothing to store) -- correct behavior
+        assert mem_msg.meta is None
+
+    # --- Other message types round-trip ---
+
+    def test_human_message_round_trip_additional_kwargs(self):
+        from langchain_core.messages import HumanMessage
+
+        from agentarts.sdk.integration.langgraph.converter import (
+            langgraph_to_memory_message,
+            memory_to_langgraph_message,
+        )
+        from agentarts.sdk.memory import MessageInfo
+
+        original = HumanMessage(content="Question", additional_kwargs={"custom": "data"})
+        mem_msg = langgraph_to_memory_message(original)
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="user",
+            parts=[{"type": "text", "text": "Question"}],
+            meta=mem_msg.meta,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "Question"
+        assert restored.additional_kwargs == {"custom": "data"}
+
+    def test_system_message_round_trip_additional_kwargs(self):
+        from langchain_core.messages import SystemMessage
+
+        from agentarts.sdk.integration.langgraph.converter import (
+            langgraph_to_memory_message,
+            memory_to_langgraph_message,
+        )
+        from agentarts.sdk.memory import MessageInfo
+
+        original = SystemMessage(content="You are helpful", additional_kwargs={"key": "val"})
+        mem_msg = langgraph_to_memory_message(original)
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="system",
+            parts=[{"type": "text", "text": "You are helpful"}],
+            meta=mem_msg.meta,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "You are helpful"
+        assert restored.additional_kwargs == {"key": "val"}
+
+    def test_tool_message_round_trip_additional_kwargs(self):
+        from langchain_core.messages import ToolMessage
+
+        from agentarts.sdk.integration.langgraph.converter import (
+            langgraph_to_memory_message,
+            memory_to_langgraph_message,
+        )
+        from agentarts.sdk.memory import MessageInfo
+
+        original = ToolMessage(
+            content="Result data",
+            tool_call_id="tc1",
+            additional_kwargs={"name": "get_weather"},
+        )
+        mem_msg = langgraph_to_memory_message(original)
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="tool",
+            parts=[{
+                "type": "tool_result",
+                "tool_result": {"tool_call_id": "tc1", "content": "Result data"},
+            }],
+            meta=mem_msg.meta,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "Result data"
+        assert restored.tool_call_id == "tc1"
+        assert restored.additional_kwargs == {"name": "get_weather"}
+
+    # --- Backward compatibility ---
+
+    def test_old_message_without_lc_keys(self):
+        """Old messages without _lc_* keys restore with empty additional_kwargs."""
+        from agentarts.sdk.integration.langgraph.converter import memory_to_langgraph_message
+        from agentarts.sdk.memory import MessageInfo
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="assistant",
+            parts=[{"type": "text", "text": "old message"}],
+            meta='{"step":1,"source":"loop"}',
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "old message"
+        assert restored.additional_kwargs == {}
+        assert restored.response_metadata == {}
+
+    def test_old_message_meta_none(self):
+        """Message with meta=None restores with empty additional_kwargs."""
+        from agentarts.sdk.integration.langgraph.converter import memory_to_langgraph_message
+        from agentarts.sdk.memory import MessageInfo
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="user",
+            parts=[{"type": "text", "text": "no meta"}],
+            meta=None,
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.additional_kwargs == {}
+
+    def test_old_message_meta_non_json(self):
+        """Message with non-JSON meta string does not crash."""
+        from agentarts.sdk.integration.langgraph.converter import memory_to_langgraph_message
+        from agentarts.sdk.memory import MessageInfo
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="user",
+            parts=[{"type": "text", "text": "bad meta"}],
+            meta="not a json string",
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.additional_kwargs == {}
+
+    # --- Backend returning meta as dict ---
+
+    def test_meta_returned_as_dict(self):
+        """Backend may return meta as dict -- should work."""
+        from agentarts.sdk.integration.langgraph.converter import memory_to_langgraph_message
+        from agentarts.sdk.memory import MessageInfo
+
+        msg_info = MessageInfo(
+            id="1", session_id="s1", seq=0, role="assistant",
+            parts=[{"type": "text", "text": "dict meta"}],
+            meta={"step": 1, "_lc_additional_kwargs": {"reasoning_content": "from dict"}},
+        )
+        restored = memory_to_langgraph_message(msg_info)
+
+        assert restored.content == "dict meta"
+        assert restored.additional_kwargs == {"reasoning_content": "from dict"}
+
+    # --- Saver checkpoint_meta coexistence ---
+
+    def test_saver_checkpoint_meta_coexists_with_lc_keys(self):
+        """Saver's checkpoint_meta keys and _lc_* keys coexist in the same JSON."""
+        import json
+
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import langgraph_to_memory_message
+
+        checkpoint_meta = json.dumps({
+            "step": 3,
+            "source": "loop",
+            "checkpoint_id": "cp-abc",
+            "checkpoint_ts": "2026-01-01T00:00:00Z",
+        })
+        ai_msg = AIMessage(
+            content="Response",
+            additional_kwargs={"reasoning_content": "thinking"},
+        )
+        mem_msg = langgraph_to_memory_message(ai_msg, meta=checkpoint_meta)
+
+        parsed = json.loads(mem_msg.meta)
+        # Saver keys preserved
+        assert parsed["step"] == 3
+        assert parsed["source"] == "loop"
+        assert parsed["checkpoint_id"] == "cp-abc"
+        # LangChain keys added
+        assert parsed["_lc_additional_kwargs"] == {"reasoning_content": "thinking"}
+
+    def test_saver_reads_checkpoint_meta_from_merged(self):
+        """Saver's reading logic (step/source) works on merged meta."""
+        import json
+
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import langgraph_to_memory_message
+
+        checkpoint_meta = json.dumps({
+            "step": 5,
+            "source": "update",
+            "checkpoint_id": "cp-xyz",
+            "checkpoint_ts": "2026-01-01T12:00:00Z",
+        })
+        ai_msg = AIMessage(
+            content="Hi",
+            additional_kwargs={"reasoning_content": "reasoning"},
+            response_metadata={"model_name": "test-model"},
+        )
+        mem_msg = langgraph_to_memory_message(ai_msg, meta=checkpoint_meta)
+
+        # Simulate saver's get_tuple() reading logic
+        meta = json.loads(mem_msg.meta)
+        assert meta.get("step", 0) == 5
+        assert meta.get("source", "loop") == "update"
+        assert meta.get("checkpoint_id") == "cp-xyz"
+        assert meta.get("checkpoint_ts") == "2026-01-01T12:00:00Z"
+
+    # --- Empty additional_kwargs not stored ---
+
+    def test_empty_additional_kwargs_not_stored(self):
+        """Messages with empty additional_kwargs should not add _lc_additional_kwargs to meta."""
+        import json
+
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import langgraph_to_memory_message
+
+        ai_msg = AIMessage(content="Hello")  # no additional_kwargs
+        mem_msg = langgraph_to_memory_message(ai_msg, meta='{"step":1}')
+
+        parsed = json.loads(mem_msg.meta)
+        assert "_lc_additional_kwargs" not in parsed
+        assert "_lc_response_metadata" not in parsed
+
+    # --- No caller_meta with additional_kwargs ---
+
+    def test_no_caller_meta_with_additional_kwargs(self):
+        """When caller_meta is None but message has additional_kwargs, meta is created."""
+        import json
+
+        from langchain_core.messages import AIMessage
+
+        from agentarts.sdk.integration.langgraph.converter import langgraph_to_memory_message
+
+        ai_msg = AIMessage(
+            content="Hello",
+            additional_kwargs={"reasoning_content": "standalone"},
+        )
+        mem_msg = langgraph_to_memory_message(ai_msg, meta=None)
+
+        assert mem_msg.meta is not None
+        parsed = json.loads(mem_msg.meta)
+        assert parsed["_lc_additional_kwargs"] == {"reasoning_content": "standalone"}
+
+
 class TestConfigIsEmptyMethods:
     """Tests for is_empty() methods in config models."""
 


### PR DESCRIPTION
### Background

The LangGraph message converter (`converter.py`) performs bidirectional conversion between LangChain messages (`BaseMessage` subclasses) and AgentArts Memory messages (`TextMessage`, `ToolCallMessage`, `ToolResultMessage`). During this conversion, two important LangChain message fields were silently discarded:

1. `additional_kwargs` — provider-specific metadata such as `reasoning_content` from deep-thinking models, custom fields set by tool integrations, or any extra key-value pairs attached by upstream components.
2. `response_metadata` — model response information such as `model_name`, `finish_reason`, and `token_usage`, typically populated by LLM providers.

Additionally, when an `AIMessage` contained both text `content` and `tool_calls`, only the tool calls were converted — the text content was silently dropped.

After a round-trip through Memory storage and back, all of this information was lost, degrading the quality of agent workflows that rely on reasoning traces, model metadata, or messages with both content and tool invocations.

### Changes

**`src/agentarts/sdk/integration/langgraph/converter.py`**

- `_parse_meta(meta)`: New helper that safely parses meta from `str` (JSON), `dict`, or `None` formats, returning `{}` for unparseable or missing input. Defensive against the type asymmetry between `TextMessage.meta` (str) and `MessageInfo.meta` (dict).
- `_build_meta(caller_meta, additional_kwargs, response_metadata, extra)`: New helper that merges the caller's existing meta (e.g., saver's checkpoint_meta) with LangChain-specific fields under `_lc_` namespaced keys (`_lc_additional_kwargs`, `_lc_response_metadata`, `_lc_content`). Returns `None` when nothing needs to be stored.
- `langgraph_to_memory_message()`: All message type branches (HumanMessage, AIMessage with/without tool_calls, SystemMessage, ToolMessage, FunctionMessage, ChatMessage, and the default fallback) now call `_build_meta()` to merge metadata before constructing the Memory message. For AIMessage with tool_calls and non-empty content, the content is stored in `_lc_content` to prevent loss.
- `memory_to_langgraph_message()`: Extracts `_lc_additional_kwargs`, `_lc_response_metadata`, and `_lc_content` from the message meta and passes them to the reconstructed LangChain message. All return branches (tool_result, tool_call, user, assistant, system, tool, default) now include `additional_kwargs`; AIMessage branches also include `response_metadata`.

**`tests/unit/sdk/integration/test_langgraph.py`**

- `TestAdditionalKwargsPreservation` (28 tests): Covers `_parse_meta` helper (7 cases: None, empty string, JSON string, empty JSON, dict, non-JSON, JSON array), `_build_meta` helper (6 cases: None caller, caller-only, with additional_kwargs, with response_metadata, with extra, empty dict not stored), AIMessage round-trip (4 cases: additional_kwargs, response_metadata, tool_calls + content preservation, tool_calls without content), other message types round-trip (3 cases: HumanMessage, SystemMessage, ToolMessage), backward compatibility (3 cases: old messages without `_lc_*` keys, meta=None, non-JSON meta), dict meta from backend (1 case), saver checkpoint_meta coexistence (2 cases), and edge cases (2 cases: empty additional_kwargs not stored, no caller_meta with additional_kwargs).

### Verification

All 51 unit tests in `tests/unit/sdk/integration/test_langgraph.py` pass, including all 28 new tests in `TestAdditionalKwargsPreservation`. An additional standalone verification script with 9 end-to-end round-trip tests also passes — it exercises the real converter functions through a simulated backend flow (LangChain → SDK → to_dict → MessageInfo → LangChain), covering reasoning_content preservation, response_metadata preservation, tool_calls + content coexistence, saver checkpoint_meta coexistence, backward compatibility with old messages, graceful degradation when meta is None, and full multi-message conversation round-trips.
