### PR TITLE
feat(integration): add Google ADK session and memory service integration

### DIFF
--- a/examples/integration/google_adk/README.md
+++ b/examples/integration/google_adk/README.md
@@ -1,0 +1,108 @@
+# Google ADK Integration Example
+
+展示如何使用 Google ADK（Agent Development Kit）创建 Agent，并通过 AgentArts 实现会话和记忆的云端持久化。
+
+## 快速开始
+
+```bash
+# 安装依赖
+pip install -r requirements.txt
+
+# 设置环境变量
+export HUAWEICLOUD_SDK_MEMORY_API_KEY="your-agentarts-api-key"
+export AGENTARTS_MEMORY_SPACE_ID="your-space-id"
+export OPENAI_API_KEY="your-openai-api-key"
+export OPENAI_MODEL_NAME="openai/gpt-4o-mini"   # 可选，默认 openai/gpt-4o-mini
+export OPENAI_BASE_URL="https://api.openai.com/v1"  # 可选
+
+# 运行示例
+python google_adk_agent.py
+```
+
+## 工作原理
+
+本示例展示了 Google ADK 与 AgentArts 的集成方式：
+
+```
+Google ADK                    AgentArts
+┌─────────────┐              ┌──────────────────┐
+│   Agent     │              │  AsyncMemoryClient│
+│  (with tools)│             │  (Memory Backend) │
+└─────┬───────┘              └────────┬─────────┘
+      │                               │
+┌─────┴───────────────────────────────┴─────────┐
+│                  Runner                        │
+│                                               │
+│  ┌─────────────────────┐ ┌──────────────────┐ │
+│  │ AgentArtsSession     │ │ AgentArtsMemory  │ │
+│  │ Service              │ │ Service          │ │
+│  │ (会话持久化)          │ │ (记忆抽取与搜索)  │ │
+│  └─────────────────────┘ └──────────────────┘ │
+└───────────────────────────────────────────────┘
+```
+
+- **AgentArtsSessionService**：将 ADK 的会话（Session）和事件（Event）持久化到 AgentArts 后端，支持 O(1) 复杂度的状态读取
+- **AgentArtsMemoryService**：将对话事件写入 AgentArts 记忆系统，支持语义搜索，自动去重（基于 idempotency_key）
+
+## Agent 配置
+
+Agent 配备了两个工具：
+
+1. **calculate** - 计算数学表达式（支持 sqrt、sin、cos、log 等）
+2. **get_current_time** - 获取当前日期和时间
+
+## 模型配置
+
+ADK 的 `Agent.model` 接受 LiteLLM 格式的字符串，支持多种 LLM 提供商：
+
+| 提供商 | model 字符串 | 所需环境变量 |
+|--------|-------------|-------------|
+| OpenAI | `openai/gpt-4o-mini` | `OPENAI_API_KEY` |
+| Gemini | `gemini/gemini-2.0-flash` | `GOOGLE_API_KEY` |
+
+## 环境变量
+
+| 变量名 | 说明 | 必需 |
+|-------|------|------|
+| `HUAWEICLOUD_SDK_MEMORY_API_KEY` | AgentArts API Key | 是 |
+| `AGENTARTS_MEMORY_SPACE_ID` | Memory Space ID | 否（默认 `default`） |
+| `OPENAI_API_KEY` | OpenAI API Key | 是（使用 OpenAI 模型时） |
+| `OPENAI_MODEL_NAME` | 模型名称（LiteLLM 格式） | 否（默认 `openai/gpt-4o-mini`） |
+| `OPENAI_BASE_URL` | API Base URL | 否 |
+
+## 常见问题
+
+### 多轮对话报错 `Missing reasoning_content`
+
+使用 DeepSeek 等推理模型时，多轮对话可能在第 4 轮左右报错：
+
+```
+BadRequestError: Missing `reasoning_content` field in the assistant message at index N
+```
+
+这是因为推理模型默认开启深度思考模式，返回的 assistant 消息包含 `reasoning_content` 字段，而 ADK 在后续轮次发送历史消息时不会携带该字段，导致 API 校验失败。
+
+**解决方法**：通过 `generate_content_config` 关闭深度思考模式。本示例的 `google_adk_agent.py` 中已预留了相关注释代码，取消注释即可。具体参数名称和取值取决于所使用的 LLM API，请参考对应 API 文档。示例：
+
+```python
+from google.genai.types import GenerateContentConfig, HttpOptions
+
+agent = Agent(
+    ...
+    generate_content_config=GenerateContentConfig(
+        http_options=HttpOptions(
+            extra_body={"thinking": {"type": "disabled"}}  # 参数因 API 而异
+        )
+    ),
+)
+```
+
+## 与其他示例的对比
+
+| 特性 | LangChain | LangGraph | Google ADK |
+|------|-----------|-----------|------------|
+| 框架 | LangChain AgentExecutor | LangGraph StateGraph | ADK Runner |
+| 持久化方式 | 由 LangChain 管理 | AgentArtsMemorySessionSaver | AgentArtsSessionService |
+| 记忆搜索 | 无 | 无 | 有（MemoryService） |
+| 状态管理 | 消息列表 | Checkpoint | Session State（O(1) 读取） |
+| 适用场景 | 简单工具调用 | 复杂状态流 | 工具调用 + 记忆管理 |

--- a/examples/integration/google_adk/google_adk_agent.py
+++ b/examples/integration/google_adk/google_adk_agent.py
@@ -1,0 +1,187 @@
+"""Google ADK Integration Example - ADK Agent with AgentArts persistence"""
+
+import asyncio
+import os
+import sys
+from datetime import datetime
+
+from google.adk.agents import Agent
+from google.adk.runners import Runner
+from google.genai import types
+# Uncomment the following imports if you need to disable thinking mode for reasoning models
+# (e.g., DeepSeek-V4-Flash) that return a `reasoning_content` field, which causes
+# `Missing reasoning_content` errors in multi-turn conversations.
+# from google.genai.types import GenerateContentConfig, HttpOptions
+
+from agentarts.sdk.integration.google_adk import (
+    AgentArtsMemoryService,
+    AgentArtsSessionService,
+)
+from agentarts.sdk.memory import AsyncMemoryClient
+
+# ============================================================================
+# 1. Tool definitions
+# ============================================================================
+
+
+def calculate(expression: str) -> str:
+    """Evaluate a mathematical expression.
+
+    Use this tool for mathematical calculations. Input should be a valid
+    Python math expression (e.g., "2 + 2", "3.14 * r**2").
+
+    Args:
+        expression: Mathematical expression to evaluate.
+
+    Returns:
+        The result of the calculation as a string.
+    """
+    import math
+
+    allowed = {
+        k: getattr(math, k)
+        for k in (
+            "sqrt", "sin", "cos", "tan", "log", "log10", "exp",
+            "pi", "e", "floor", "ceil", "pow", "fabs",
+        )
+        if hasattr(math, k)
+    }
+    allowed.update({"abs": abs, "round": round, "min": min, "max": max})
+    try:
+        return str(eval(expression, {"__builtins__": {}}, allowed))
+    except Exception as exc:
+        return f"Error: {exc}"
+
+
+def get_current_time() -> str:
+    """Get the current date and time.
+
+    Returns:
+        Current date and time as a formatted string.
+    """
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ============================================================================
+# 2. Environment variable validation
+# ============================================================================
+
+_required_vars = ["HUAWEICLOUD_SDK_MEMORY_API_KEY", "OPENAI_API_KEY"]
+_missing_vars = [v for v in _required_vars if not os.getenv(v)]
+if _missing_vars:
+    print(f"ERROR: Missing required environment variables: {', '.join(_missing_vars)}")
+    print("Please set them before running this example.")
+    sys.exit(1)
+
+# ============================================================================
+# 3. AgentArts services setup
+# ============================================================================
+
+# AsyncMemoryClient reads credentials from environment variables:
+#   HUAWEICLOUD_SDK_MEMORY_API_KEY  - API Key for authentication
+#   HUAWEICLOUD_SDK_REGION_NAME     - Region (optional, auto-detected)
+_memory_client = AsyncMemoryClient()
+
+_session_service = AgentArtsSessionService(_memory_client)
+_memory_service = AgentArtsMemoryService(_memory_client)
+
+SPACE_ID = os.getenv("AGENTARTS_MEMORY_SPACE_ID", "default")
+
+# ============================================================================
+# 4. ADK Agent definition
+# ============================================================================
+
+# Agent.model accepts a string in LiteLLM format: "provider/model-name"
+# OpenAI:   "openai/gpt-4o-mini"   (requires OPENAI_API_KEY)
+# Gemini:   "gemini/gemini-2.0-flash" (requires GOOGLE_API_KEY)
+_model_name = os.getenv("OPENAI_MODEL_NAME", "openai/gpt-4o-mini")
+MODEL_NAME = _model_name if "/" in _model_name else f"openai/{_model_name}"
+
+agent = Agent(
+    name="assistant",
+    model=MODEL_NAME,
+    description="A helpful assistant with calculator and time tools.",
+    tools=[calculate, get_current_time],
+    # Uncomment below to disable thinking mode for reasoning models (e.g., DeepSeek-V4-Flash).
+    # The exact parameter names and values depend on the LLM API you are using.
+    # generate_content_config=GenerateContentConfig(
+    #     http_options=HttpOptions(
+    #         extra_body={"thinking": {"type": "disabled"}}
+    #     )
+    # ),
+)
+
+# ============================================================================
+# 5. ADK Runner (wired with AgentArts services)
+# ============================================================================
+
+runner = Runner(
+    app_name=SPACE_ID,
+    agent=agent,
+    session_service=_session_service,
+    memory_service=_memory_service,
+    auto_create_session=True,
+)
+
+
+# ============================================================================
+# 6. Helper: run a single turn and collect the text response
+# ============================================================================
+
+
+async def run_turn(session_id: str, user_message: str) -> str:
+    """Send a user message and collect the agent's text response."""
+    new_message = types.Content(role="user", parts=[types.Part(text=user_message)])
+
+    response_text = ""
+    async for event in runner.run_async(
+        user_id="demo-user",
+        session_id=session_id,
+        new_message=new_message,
+    ):
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text:
+                    response_text += part.text
+
+    return response_text
+
+
+# ============================================================================
+# 7. Demo
+# ============================================================================
+
+
+async def demo():
+    """Run a multi-turn conversation to demonstrate session persistence."""
+    import uuid
+
+    session_id = uuid.uuid4().hex[:8]
+    print(f"Session: {session_id}")
+    print("-" * 40)
+
+    turns = [
+        "Hello! What tools do you have?",
+        "What is the square root of 144?",
+        "What time is it now?",
+        "What did I ask you in this conversation?",
+    ]
+
+    for msg in turns:
+        print(f"\nUser: {msg}")
+        reply = await run_turn(session_id, msg)
+        print(f"Agent: {reply}")
+
+
+if __name__ == "__main__":
+    print("Google ADK + AgentArts Integration Example")
+    print()
+    print("Required environment variables:")
+    print("  HUAWEICLOUD_SDK_MEMORY_API_KEY  - AgentArts API Key")
+    print("  AGENTARTS_MEMORY_SPACE_ID       - Memory Space ID (default: 'default')")
+    print("  OPENAI_API_KEY                  - OpenAI API Key")
+    print("  OPENAI_MODEL_NAME               - Model name (default: openai/gpt-4o-mini)")
+    print("  OPENAI_BASE_URL                 - API Base URL (optional)")
+    print()
+
+    asyncio.run(demo())

--- a/examples/integration/google_adk/requirements.txt
+++ b/examples/integration/google_adk/requirements.txt
@@ -1,0 +1,3 @@
+google-adk>=2.0.0
+litellm>=1.0.0
+agentarts-sdk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ langgraph = [
     "langchain>=1.0.0",
     "langchain-core>=1.0.0",
 ]
+google-adk = [
+    "google-adk>=2.0.0",
+]
 autogen = [
     "pyautogen>=0.2.0",
 ]
@@ -130,7 +133,7 @@ tui = [
     "textual>=0.86.0",
 ]
 all = [
-    "agentarts-sdk[web,langchain,langgraph,autogen,crewai,vector-stores,database,monitoring,huaweicloud,docs,tui]",
+    "agentarts-sdk[web,langchain,langgraph,google-adk,autogen,crewai,vector-stores,database,monitoring,huaweicloud,docs,tui]",
 ]
 
 [project.urls]

--- a/src/agentarts/sdk/integration/__init__.py
+++ b/src/agentarts/sdk/integration/__init__.py
@@ -5,6 +5,7 @@ Provides adapters for popular agent frameworks with lazy loading support.
 
 Supported frameworks:
 - LangGraph (Priority)
+- Google ADK
 - LangChain
 - AutoGen
 - CrewAI
@@ -18,9 +19,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agentarts.sdk.integration.base import BaseAdapter, WrappedAgent
+    from agentarts.sdk.integration.google_adk import (
+        AgentArtsMemoryService,
+        AgentArtsSessionService,
+    )
     from agentarts.sdk.integration.langgraph import LangGraphAdapter
 
 __all__ = [
+    "AgentArtsMemoryService",
+    "AgentArtsSessionService",
     "BaseAdapter",
     "LangGraphAdapter",
     "WrappedAgent",
@@ -30,6 +37,8 @@ _ADAPTER_MODULES = {
     "BaseAdapter": "agentarts.sdk.integration.base",
     "WrappedAgent": "agentarts.sdk.integration.base",
     "LangGraphAdapter": "agentarts.sdk.integration.langgraph",
+    "AgentArtsSessionService": "agentarts.sdk.integration.google_adk",
+    "AgentArtsMemoryService": "agentarts.sdk.integration.google_adk",
 }
 
 
@@ -57,6 +66,16 @@ def __getattr__(name: str):
                 f"{name} requires the 'langgraph' extra to be installed. "
                 f"Install it with:\n"
                 f"  pip install agentarts-sdk[langgraph]\n"
+                f"Original error: {e}"
+            )
+            raise ImportError(
+                msg
+            ) from e
+        if name in ("AgentArtsSessionService", "AgentArtsMemoryService"):
+            msg = (
+                f"{name} requires the 'google-adk' extra to be installed. "
+                f"Install it with:\n"
+                f"  pip install agentarts-sdk[google-adk]\n"
                 f"Original error: {e}"
             )
             raise ImportError(

--- a/src/agentarts/sdk/integration/google_adk/__init__.py
+++ b/src/agentarts/sdk/integration/google_adk/__init__.py
@@ -1,0 +1,34 @@
+"""
+AgentArts Google ADK Integration
+
+Provides session and memory services for Google Agent Development Kit (ADK):
+
+- AgentArtsSessionService: Persistent session management via AgentArts Memory
+- AgentArtsMemoryService: Memory ingestion and semantic search
+
+Usage:
+    from agentarts.sdk.integration.google_adk import (
+        AgentArtsMemoryService,
+        AgentArtsSessionService,
+    )
+    from agentarts.sdk.memory import AsyncMemoryClient
+
+    client = AsyncMemoryClient(api_key="...", region_name="...")
+    session_service = AgentArtsSessionService(client)
+    memory_service = AgentArtsMemoryService(client)
+"""
+
+from agentarts.sdk.integration.google_adk.converter import (
+    _STATE_KEY,
+    event_to_messages,
+    message_to_event,
+)
+from agentarts.sdk.integration.google_adk.memory_service import AgentArtsMemoryService
+from agentarts.sdk.integration.google_adk.session_service import AgentArtsSessionService
+
+__all__ = [
+    "AgentArtsMemoryService",
+    "AgentArtsSessionService",
+    "event_to_messages",
+    "message_to_event",
+]

--- a/src/agentarts/sdk/integration/google_adk/converter.py
+++ b/src/agentarts/sdk/integration/google_adk/converter.py
@@ -1,0 +1,417 @@
+"""
+Message Converters for Google ADK Integration
+
+Provides bidirectional conversion between ADK Events and
+AgentArts Memory service messages.
+
+State encoding strategy (Plan B - full snapshot):
+    Each append_event stores the complete session-scoped state in
+    message.meta under the ``_STATE_KEY``. Reading state only requires
+    fetching the last message (k=1), avoiding full history replay.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from agentarts.sdk.memory import (
+    MessageInfo,
+    TextMessage,
+    ToolCallMessage,
+    ToolResultMessage,
+)
+
+try:
+    from google.adk.events.event import Event
+    from google.adk.memory.base_memory_service import SearchMemoryResponse
+    from google.adk.memory.memory_entry import MemoryEntry
+    from google.adk.sessions.state import State
+    from google.genai import types
+
+    ADK_AVAILABLE = True
+except ImportError:
+    ADK_AVAILABLE = False
+    Event = None  # type: ignore[assignment,misc]
+    SearchMemoryResponse = None  # type: ignore[assignment,misc]
+    MemoryEntry = None  # type: ignore[assignment,misc]
+    State = None  # type: ignore[assignment,misc]
+    types = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+# Key under which the full session-scoped state snapshot is stored in message.meta.
+_STATE_KEY = "_adk_state"
+
+
+def _parse_meta(meta: str | dict | None) -> dict:
+    """Parse meta from backend response.
+
+    Handles both str (JSON string) and dict (already parsed) formats.
+    Returns empty dict if meta is None or unparseable.
+    """
+    if not meta:
+        return {}
+    if isinstance(meta, dict):
+        return dict(meta)
+    if isinstance(meta, str):
+        try:
+            result = json.loads(meta)
+            return result if isinstance(result, dict) else {}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return {}
+
+
+def _extract_session_scoped_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Filter state to only session-scoped keys.
+
+    Excludes ``app:``, ``user:``, and ``temp:`` prefixed keys.
+    Temp-scoped state is already trimmed by the base class's
+    ``_trim_temp_delta_state`` before reaching here, but we filter
+    defensively.
+    """
+    return {
+        key: value
+        for key, value in state.items()
+        if not key.startswith(State.APP_PREFIX)
+        and not key.startswith(State.USER_PREFIX)
+        and not key.startswith(State.TEMP_PREFIX)
+    }
+
+
+def event_to_messages(
+    event: Event,
+    full_state: dict[str, Any] | None = None,
+) -> list[TextMessage | ToolCallMessage | ToolResultMessage]:
+    """Convert an ADK Event to a list of AgentArts messages.
+
+    Each part of the Event's content becomes a separate message:
+        - text parts            -> TextMessage
+        - function_call parts   -> ToolCallMessage
+        - function_response parts -> ToolResultMessage
+
+    Metadata encoding for round-trip fidelity:
+        - ``_adk_event_id``: original Event.id (for grouping on read)
+        - ``_adk_author``: original Event.author (for tool messages)
+        - ``_adk_function_response_name``: FunctionResponse.name (for tool_result)
+        - ``_adk_state``: full session state snapshot (last message only)
+
+    Args:
+        event: ADK Event object.
+        full_state: If provided, the complete session-scoped state is
+            encoded into ``message.meta`` under ``_STATE_KEY`` on the
+            **last** message in the list. This lets readers recover the
+            latest state via ``get_last_k_messages(k=1)`` without
+            replaying full history. Used by SessionService.append_event
+            for state persistence.
+
+    Returns:
+        List of AgentArts messages. For pure state-update events
+        (no content parts), returns a single TextMessage with a
+        ``[state_update]`` placeholder so that ``TextMessage.to_dict()``
+        does not raise on empty content.
+
+    Raises:
+        ImportError: If google-adk is not installed.
+    """
+    if not ADK_AVAILABLE:
+        msg = (
+            "google-adk is required for event conversion. "
+            "Install it with: pip install google-adk"
+        )
+        raise ImportError(msg)
+
+    author = event.author or "user"
+    role = "user" if author == "user" else "assistant"
+
+    # Base metadata for all messages from this event (for grouping on read)
+    base_meta = {"_adk_event_id": event.id}
+
+    messages: list[TextMessage | ToolCallMessage | ToolResultMessage] = []
+
+    if event.content and event.content.parts:
+        for part in event.content.parts:
+            if part.text:
+                msg_meta = {**base_meta, "_adk_author": author}
+                messages.append(TextMessage(
+                    role=role,
+                    content=part.text,
+                    meta=json.dumps(msg_meta, ensure_ascii=False),
+                ))
+            elif part.function_call:
+                fc = part.function_call
+                msg_meta = {**base_meta, "_adk_author": author}
+                messages.append(ToolCallMessage(
+                    id=fc.id or "",
+                    name=fc.name or "",
+                    arguments=json.dumps(fc.args or {}, ensure_ascii=False),
+                    meta=json.dumps(msg_meta, ensure_ascii=False),
+                ))
+            elif part.function_response:
+                fr = part.function_response
+                msg_meta = {
+                    **base_meta,
+                    "_adk_author": author,
+                    "_adk_function_response_name": fr.name or "",
+                }
+                messages.append(ToolResultMessage(
+                    tool_call_id=fr.id or "",
+                    content=json.dumps(fr.response or {}, ensure_ascii=False),
+                    meta=json.dumps(msg_meta, ensure_ascii=False),
+                ))
+
+    # Pure state-update events (no content) use placeholder text,
+    # because TextMessage.to_dict() requires content to be non-empty.
+    if not messages:
+        placeholder_meta = {**base_meta, "_adk_author": author}
+        messages.append(TextMessage(
+            role=role,
+            content="[state_update]",
+            meta=json.dumps(placeholder_meta, ensure_ascii=False),
+        ))
+
+    # Attach state snapshot to the last message so that
+    # get_last_k_messages(k=1) retrieves the latest state.
+    if full_state is not None:
+        last_meta = _parse_meta(messages[-1].meta)
+        last_meta[_STATE_KEY] = full_state
+        messages[-1].meta = json.dumps(last_meta, ensure_ascii=False)
+
+    return messages
+
+
+def message_to_event(message: MessageInfo) -> Event:
+    """Convert an AgentArts MessageInfo to an ADK Event.
+
+    Reconstructs the Event with content parts and state_delta (if
+    ``_STATE_KEY`` is present in message.meta).
+
+    Metadata extraction for round-trip fidelity:
+        - ``_adk_author``: restores original Event.author for tool messages
+        - ``_adk_function_response_name``: restores FunctionResponse.name
+
+    Args:
+        message: AgentArts Memory MessageInfo.
+
+    Returns:
+        ADK Event.
+
+    Raises:
+        ImportError: If google-adk is not installed.
+    """
+    if not ADK_AVAILABLE:
+        msg = (
+            "google-adk is required for event conversion. "
+            "Install it with: pip install google-adk"
+        )
+        raise ImportError(msg)
+
+    # Extract metadata for round-trip fidelity
+    meta_dict = _parse_meta(getattr(message, "meta", None))
+
+    # Restore author from meta for tool and assistant messages.
+    # For user messages, author is always "user".
+    if message.role == "user":
+        author = "user"
+    else:
+        author = meta_dict.get("_adk_author", message.assistant_id or "assistant")
+
+    content_role = "user" if message.role == "user" else "model"
+
+    # Build Content parts from message parts
+    parts: list[types.Part] = []
+    if message.parts:
+        for part in message.parts:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type", "")
+
+            if part_type == "text":
+                text = part.get("text", "")
+                if text:
+                    parts.append(types.Part(text=text))
+            elif part_type == "tool_call":
+                tool_call = part.get("tool_call", {})
+                if tool_call:
+                    fc = types.FunctionCall(
+                        id=tool_call.get("id", ""),
+                        name=tool_call.get("name", ""),
+                        args=json.loads(tool_call.get("arguments", "{}")),
+                    )
+                    parts.append(types.Part(function_call=fc))
+            elif part_type == "tool_result":
+                tool_result = part.get("tool_result", {})
+                if tool_result:
+                    # Fix: decode response from JSON string instead of wrapping
+                    raw_content = tool_result.get("content", "")
+                    try:
+                        response = json.loads(raw_content) if raw_content else {}
+                    except json.JSONDecodeError:
+                        response = {"result": raw_content}
+
+                    # Restore FunctionResponse.name from meta
+                    fr_name = meta_dict.get("_adk_function_response_name", "")
+
+                    fr = types.FunctionResponse(
+                        id=tool_result.get("tool_call_id", ""),
+                        name=fr_name,
+                        response=response,
+                    )
+                    parts.append(types.Part(function_response=fr))
+
+    content = types.Content(role=content_role, parts=parts) if parts else None
+
+    # Extract state from meta if present
+    state_delta = None
+    if _STATE_KEY in meta_dict:
+        state_delta = meta_dict[_STATE_KEY]
+        if isinstance(state_delta, str):
+            state_delta = json.loads(state_delta)
+
+    # Convert timestamp: backend uses milliseconds (int), ADK uses seconds (float)
+    timestamp = 0.0
+    if message.message_time:
+        timestamp = float(message.message_time) / 1000.0
+
+    # Build Event
+    # Restore original Event.id from meta (preferred over backend message ID)
+    event_id = meta_dict.get("_adk_event_id") or message.id
+    event_kwargs: dict[str, Any] = {
+        "id": event_id,
+        "author": author,
+        "timestamp": timestamp,
+        "content": content,
+    }
+    if state_delta is not None:
+        event_kwargs["state"] = state_delta
+
+    return Event(**event_kwargs)
+
+
+def _messages_to_events(messages: list[MessageInfo]) -> list[Event]:
+    """Group consecutive messages by _adk_event_id and merge into Events.
+
+    Messages with the same consecutive ``_adk_event_id`` are merged into
+    a single Event with multiple parts. Messages without ``_adk_event_id``
+    (backward compatibility) are treated as individual Events.
+
+    This restores the original Event structure after persistence, since
+    ``event_to_messages`` splits one Event with N parts into N messages.
+
+    Args:
+        messages: List of AgentArts MessageInfo objects.
+
+    Returns:
+        List of ADK Events with parts merged from consecutive messages.
+    """
+    if not messages:
+        return []
+
+    events: list[Event] = []
+    current_group: list[MessageInfo] = []
+    current_event_id: str | None = None
+
+    for msg in messages:
+        meta = _parse_meta(getattr(msg, "meta", None))
+        event_id = meta.get("_adk_event_id")
+
+        # Group consecutive messages with the same event_id
+        if event_id and event_id == current_event_id:
+            current_group.append(msg)
+        else:
+            # Flush previous group
+            if current_group:
+                events.append(_merge_group_to_event(current_group))
+            current_group = [msg]
+            current_event_id = event_id
+
+    # Flush last group
+    if current_group:
+        events.append(_merge_group_to_event(current_group))
+
+    return events
+
+
+def _merge_group_to_event(messages: list[MessageInfo]) -> Event:
+    """Merge a group of messages into a single Event with multiple parts.
+
+    Args:
+        messages: List of consecutive MessageInfo objects with the same
+            ``_adk_event_id``.
+
+    Returns:
+        ADK Event with parts merged from all messages. The Event.id is
+        restored from ``_adk_event_id`` in meta (not the backend message ID).
+    """
+    if len(messages) == 1:
+        return message_to_event(messages[0])
+
+    # Convert all messages to Events
+    events = [message_to_event(msg) for msg in messages]
+
+    # Merge parts from all Events into the first one
+    merged = events[0]
+    for event in events[1:]:
+        if event.content and event.content.parts:
+            if merged.content is None:
+                merged.content = event.content
+            else:
+                merged.content.parts.extend(event.content.parts)
+        # State from later events overrides earlier ones
+        event_state = getattr(getattr(event, "actions", None), "state_delta", None)
+        if event_state:
+            if merged.actions is None:
+                # Create actions if it doesn't exist
+                from google.adk.events.event import EventActions
+                merged.actions = EventActions(state_delta=event_state)
+            else:
+                merged.actions.state_delta = event_state
+
+    # Restore original Event.id from meta (not the backend message ID)
+    first_meta = _parse_meta(getattr(messages[0], "meta", None))
+    original_id = first_meta.get("_adk_event_id")
+    if original_id:
+        merged.id = original_id
+
+    return merged
+
+
+def _convert_search_response(response) -> SearchMemoryResponse:
+    """Convert SDK MemorySearchResponse to ADK SearchMemoryResponse.
+
+    Backend returns results as ``[{"record": {...}, "score": float}]``.
+    Each record contains fields like ``content``, ``id``, etc.
+
+    Args:
+        response: AgentArts SDK MemorySearchResponse.
+
+    Returns:
+        ADK SearchMemoryResponse.
+    """
+    if not ADK_AVAILABLE:
+        msg = (
+            "google-adk is required for search response conversion. "
+            "Install it with: pip install google-adk"
+        )
+        raise ImportError(msg)
+
+    memories: list[MemoryEntry] = []
+    for result in response.results:
+        record = result.get("record", {})
+        score = result.get("score", 0.0)
+
+        content_text = record.get("content", "")
+        memory_id = record.get("id")
+
+        entry = MemoryEntry(
+            content=types.Content(
+                parts=[types.Part(text=content_text)]
+            ),
+            id=memory_id,
+            custom_metadata={"score": score},
+        )
+        memories.append(entry)
+
+    return SearchMemoryResponse(memories=memories)

--- a/src/agentarts/sdk/integration/google_adk/memory_service.py
+++ b/src/agentarts/sdk/integration/google_adk/memory_service.py
@@ -1,0 +1,155 @@
+"""
+AgentArts Memory Service for Google ADK
+
+Implements ``BaseMemoryService`` by ingesting conversation events into
+the AgentArts Memory backend for semantic search and memory extraction.
+
+Deduplication strategy (idempotency_key + 409 fallback):
+    When ``SessionService.append_event`` has already persisted an event,
+    ``MemoryService.add_session_to_memory`` would re-ingest it. To prevent
+    duplicates, every ``add_messages`` call uses
+    ``idempotency_key=f"{session_id}:{event.id}"``. The backend rejects
+    duplicates with 409 Conflict before any DB write, so the overhead is
+    negligible.
+
+Asynchronous extraction:
+    The AgentArts backend performs memory extraction asynchronously.
+    ``is_force_extract=True`` is safe and triggers extraction, but is not
+    required for correctness.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+
+from agentarts.sdk.memory import AsyncMemoryClient, MemorySearchFilter
+from agentarts.sdk.service import APIException
+
+try:
+    from google.adk.events.event import Event
+    from google.adk.memory.base_memory_service import (
+        BaseMemoryService,
+        SearchMemoryResponse,
+    )
+    from google.adk.sessions.session import Session
+
+    ADK_AVAILABLE = True
+except ImportError:
+    ADK_AVAILABLE = False
+    BaseMemoryService = object  # type: ignore[assignment,misc]
+    SearchMemoryResponse = None  # type: ignore[assignment,misc]
+    Session = None  # type: ignore[assignment,misc]
+    Event = None  # type: ignore[assignment,misc]
+
+from agentarts.sdk.integration.google_adk.converter import (
+    _convert_search_response,
+    event_to_messages,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AgentArtsMemoryService(BaseMemoryService):
+    """ADK MemoryService backed by AgentArts Memory.
+
+    Provides:
+        - ``add_session_to_memory``: Ingest all session events (with dedup).
+        - ``add_events_to_memory``: Ingest a subset of events (incremental).
+        - ``search_memory``: Semantic search over stored memories.
+    """
+
+    def __init__(self, client: AsyncMemoryClient):
+        self._client = client
+
+    async def _try_add_event(
+        self,
+        event: Event,
+        session_id: str,
+        space_id: str,
+    ) -> None:
+        """Add a single event as a message, with idempotency-key dedup.
+
+        Skips events with no content parts (pure state updates).
+        Catches 409 Conflict silently - the message is already persisted.
+
+        Guards against ``event.id`` being None (e.g., externally
+        constructed Events) by assigning a UUID so the idempotency key
+        does not collapse to ``"session_id:None"``.
+        """
+        if not event.id:
+            import uuid
+            event.id = str(uuid.uuid4())
+
+        if not (event.content and event.content.parts):
+            return
+
+        messages = event_to_messages(event)
+        try:
+            await self._client.add_messages(
+                space_id=space_id,
+                session_id=session_id,
+                messages=messages,
+                idempotency_key=f"{session_id}:{event.id}",
+                is_force_extract=True,
+            )
+        except APIException as e:
+            if e.status_code == 409:
+                logger.debug(
+                    "Event %s already ingested for session %s, skipping.",
+                    event.id,
+                    session_id,
+                )
+            else:
+                raise
+
+    async def add_session_to_memory(self, session: Session) -> None:
+        """Ingest all session events into memory.
+
+        A session may be added multiple times; idempotency keys ensure
+        no duplicates are created.
+        """
+        for event in session.events:
+            await self._try_add_event(event, session.id, session.app_name)
+
+    async def add_events_to_memory(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        events: Sequence[Event],
+        session_id: str | None = None,
+        custom_metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        """Ingest an incremental list of events (delta) into memory.
+
+        Prefer this over ``add_session_to_memory`` when you only need
+        to persist the latest turn - it avoids iterating the full
+        session history and issuing unnecessary 409s.
+        """
+        sid = session_id or "__unknown_session_id__"
+        for event in events:
+            await self._try_add_event(event, sid, app_name)
+
+    async def search_memory(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        query: str,
+    ) -> SearchMemoryResponse:
+        """Semantic search over stored memories.
+
+        Args:
+            app_name: AgentArts space ID.
+            user_id: AgentArts actor ID (used as filter).
+            query: Natural-language search query.
+
+        Returns:
+            ADK SearchMemoryResponse with matching memory entries.
+        """
+        response = await self._client.search_memories(
+            space_id=app_name,
+            filters=MemorySearchFilter(query=query, actor_id=user_id),
+        )
+        return _convert_search_response(response)

--- a/src/agentarts/sdk/integration/google_adk/session_service.py
+++ b/src/agentarts/sdk/integration/google_adk/session_service.py
@@ -1,0 +1,313 @@
+"""
+AgentArts Session Service for Google ADK
+
+Implements ``BaseSessionService`` by persisting sessions and events
+to the AgentArts Memory backend.
+
+State management strategy (Plan B - full snapshot):
+    - **Write**: Each ``append_event`` stores the complete session-scoped
+      state in ``message.meta`` under ``_STATE_KEY``.
+    - **Read**: State is recovered from the last message's meta (k=1),
+      avoiding full history replay. O(1) complexity.
+    - Only ``session:`` scoped state is persisted. ``user:`` / ``app:``
+      scoped state is silently dropped.
+
+Deduplication:
+    Each ``append_event`` uses ``idempotency_key=f"{session_id}:{event.id}"``
+    so that re-ingestion by ``MemoryService.add_session_to_memory`` is a
+    no-op (409 Conflict, silently caught).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from agentarts.sdk.service import APIException
+
+if TYPE_CHECKING:
+    from agentarts.sdk.memory import AsyncMemoryClient, MessageInfo
+
+try:
+    from google.adk.events.event import Event
+    from google.adk.sessions.base_session_service import (
+        BaseSessionService,
+        GetSessionConfig,
+        ListSessionsResponse,
+    )
+    from google.adk.sessions.session import Session
+    from google.adk.sessions.state import State
+
+    ADK_AVAILABLE = True
+except ImportError:
+    ADK_AVAILABLE = False
+    BaseSessionService = object  # type: ignore[assignment,misc]
+    GetSessionConfig = None  # type: ignore[assignment,misc]
+    ListSessionsResponse = None  # type: ignore[assignment,misc]
+    Session = None  # type: ignore[assignment,misc]
+    State = None  # type: ignore[assignment,misc]
+    Event = None  # type: ignore[assignment,misc]
+
+from agentarts.sdk.integration.google_adk.converter import (
+    _STATE_KEY,
+    _extract_session_scoped_state,
+    _messages_to_events,
+    _parse_meta,
+    event_to_messages,
+)
+
+logger = logging.getLogger(__name__)
+
+# Page size limit enforced by the backend.
+_PAGE_SIZE = 20
+
+# Conservative upper bound on parts per Event. Used to over-fetch messages
+# so that ``_messages_to_events`` can group enough messages to satisfy
+# ``num_recent_events``. ADK Events rarely exceed 5 parts (text +
+# function_call + function_response), so 10 is a safe multiplier.
+_MAX_PARTS_PER_EVENT = 10
+
+
+class AgentArtsSessionService(BaseSessionService):
+    """ADK SessionService backed by AgentArts Memory.
+
+    Maps ADK concepts to AgentArts as follows:
+        - ``app_name`` -> ``space_id``
+        - ``user_id`` -> ``actor_id``
+        - ``session_id`` -> ``session_id``
+        - ``Session.events`` -> ``messages``
+        - ``Session.state`` -> encoded in ``message.meta`` (full snapshot)
+    """
+
+    def __init__(self, client: AsyncMemoryClient):
+        self._client = client
+
+    async def create_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        state: dict[str, Any] | None = None,
+        session_id: str | None = None,
+    ) -> Session:
+        """Create a new session in AgentArts.
+
+        Initial state is NOT stored in session.meta; the first
+        ``append_event`` will carry the full state snapshot.
+        """
+        session_info = await self._client.create_memory_session(
+            space_id=app_name,
+            id=session_id,
+            actor_id=user_id,
+        )
+        return Session(
+            id=session_info.id,
+            app_name=app_name,
+            user_id=user_id,
+            state=state or {},
+            events=[],
+            last_update_time=0.0,
+        )
+
+    async def get_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        config: GetSessionConfig | None = None,
+    ) -> Session | None:
+        """Retrieve a session from AgentArts.
+
+        State is read from the last message's meta (k=1, O(1)).
+        Events are loaded per ``config.num_recent_events``.
+        """
+        # 1. Verify session exists
+        try:
+            await self._client.get_session(
+                space_id=app_name, session_id=session_id
+            )
+        except APIException as e:
+            if e.status_code == 404:
+                return None
+            raise
+
+        # 2. Read full state from the last message's meta
+        state: dict[str, Any] = {}
+        last_messages = await self._client.get_last_k_messages(
+            session_id=session_id, k=1, space_id=app_name
+        )
+        if last_messages:
+            meta_dict = _parse_meta(getattr(last_messages[0], "meta", None))
+            if _STATE_KEY in meta_dict:
+                stored_state = meta_dict[_STATE_KEY]
+                if isinstance(stored_state, str):
+                    stored_state = json.loads(stored_state)
+                if isinstance(stored_state, dict):
+                    state = stored_state
+
+        # 3. Load events (controlled by config.num_recent_events)
+        #    ADK's num_recent_events counts Events, not messages. Since one
+        #    Event can span multiple messages (one per part), we over-fetch
+        #    by _MAX_PARTS_PER_EVENT to ensure enough messages are retrieved,
+        #    then trim the resulting Event list to the requested count.
+        target_count = config.num_recent_events if config else None
+        if target_count == 0:
+            events: list[Event] = []
+        else:
+            fetch_count = (
+                target_count * _MAX_PARTS_PER_EVENT
+                if target_count is not None
+                else None
+            )
+            all_messages = await self._fetch_messages(
+                app_name, session_id, fetch_count
+            )
+            events = _messages_to_events(all_messages)
+            if target_count is not None:
+                events = events[-target_count:]
+
+        # 4. Filter by after_timestamp
+        if config and config.after_timestamp:
+            events = [e for e in events if e.timestamp >= config.after_timestamp]
+
+        last_update_time = events[-1].timestamp if events else 0.0
+
+        return Session(
+            id=session_id,
+            app_name=app_name,
+            user_id=user_id,
+            state=state,
+            events=events,
+            last_update_time=last_update_time,
+        )
+
+    async def _fetch_messages(
+        self,
+        space_id: str,
+        session_id: str,
+        target_count: int | None,
+    ) -> list[MessageInfo]:
+        """Fetch messages with pagination, respecting the backend's
+        ``limit=20`` hard cap.
+
+        Args:
+            target_count: ``None`` = load all, ``>0`` = load most recent N.
+        """
+        # Simple path: small count fits in one page
+        if target_count is not None and target_count <= _PAGE_SIZE:
+            return await self._client.get_last_k_messages(
+                session_id=session_id, k=target_count, space_id=space_id
+            )
+
+        # Paginated path: use list_messages
+        first = await self._client.list_messages(
+            space_id=space_id, session_id=session_id, limit=1, offset=0
+        )
+        total = first.total
+
+        if target_count is None:
+            need = total
+            start_offset = 0
+            logger.info(
+                "Loading all messages for session %s (total=%d). "
+                "Consider setting num_recent_events for better performance.",
+                session_id,
+                total,
+            )
+        else:
+            need = min(target_count, total)
+            start_offset = max(0, total - need)
+
+        messages: list[MessageInfo] = []
+        offset = start_offset
+        remaining = need
+        while remaining > 0:
+            batch_size = min(_PAGE_SIZE, remaining)
+            page = await self._client.list_messages(
+                space_id=space_id,
+                session_id=session_id,
+                limit=batch_size,
+                offset=offset,
+            )
+            messages.extend(page.items)
+            offset += len(page.items)
+            remaining -= len(page.items)
+            if len(page.items) < batch_size:
+                break  # reached end
+
+        return messages
+
+    async def list_sessions(
+        self,
+        *,
+        app_name: str,
+        user_id: str | None = None,
+    ) -> ListSessionsResponse:
+        """List sessions for a user in an app."""
+        response = await self._client.list_sessions(
+            space_id=app_name, actor_id=user_id
+        )
+        sessions = [
+            Session(
+                id=s.id,
+                app_name=app_name,
+                user_id=s.actor_id or "",
+                state={},
+                events=[],
+            )
+            for s in response.items
+        ]
+        return ListSessionsResponse(sessions=sessions)
+
+    async def delete_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> None:
+        """Delete a session from AgentArts."""
+        await self._client.delete_session(
+            space_id=app_name, session_id=session_id
+        )
+
+    async def append_event(self, session: Session, event: Event) -> Event:
+        """Append an event to the session and persist to AgentArts.
+
+        1. Calls the base class to update in-memory state and events.
+        2. Extracts session-scoped state (excluding ``app:``/``user:``/``temp:``).
+        3. Encodes the full state snapshot into ``message.meta``.
+        4. Persists via ``add_messages`` with an idempotency key to
+           prevent duplicates.
+        """
+        # 1. Base class: apply temp state, trim temp delta, update session state
+        event = await super().append_event(session=session, event=event)
+
+        # 2. Extract session-scoped state
+        session_state = _extract_session_scoped_state(session.state)
+
+        # 3. Convert event to messages with full state snapshot
+        messages = event_to_messages(event, full_state=session_state)
+
+        # 4. Persist with idempotency key (dedup via 409 fallback)
+        try:
+            await self._client.add_messages(
+                space_id=session.app_name,
+                session_id=session.id,
+                messages=messages,
+                idempotency_key=f"{session.id}:{event.id}",
+            )
+        except APIException as e:
+            if e.status_code == 409:
+                # Already persisted (e.g., by MemoryService), skip
+                logger.debug(
+                    "Event %s already persisted for session %s, skipping.",
+                    event.id,
+                    session.id,
+                )
+            else:
+                raise
+
+        return event

--- a/tests/unit/sdk/integration/test_adk_converter.py
+++ b/tests/unit/sdk/integration/test_adk_converter.py
@@ -1,0 +1,1020 @@
+"""
+Unit tests for Google ADK converter module.
+
+Tests cover:
+- _parse_meta helper
+- _extract_session_scoped_state
+- event_to_messages (all part types, state placement, placeholder)
+- message_to_event (id/author/state recovery, timestamp conversion)
+- _messages_to_events (grouping logic)
+- _merge_group_to_event (single/multi message paths)
+- _convert_search_response
+- Round-trip fidelity tests (critical for verifying review fixes)
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from google.adk.events.event import Event
+from google.genai import types
+
+from agentarts.sdk.integration.google_adk.converter import (
+    _STATE_KEY,
+    _convert_search_response,
+    _extract_session_scoped_state,
+    _merge_group_to_event,
+    _messages_to_events,
+    _parse_meta,
+    event_to_messages,
+    message_to_event,
+)
+from agentarts.sdk.memory import (
+    MessageInfo,
+    TextMessage,
+    ToolCallMessage,
+    ToolResultMessage,
+)
+
+# --- Helpers ---
+
+def _make_text_event(event_id="evt-1", author="user", text="Hello", state=None):
+    """Helper: create ADK Event with text part."""
+    kwargs = {
+        "id": event_id,
+        "author": author,
+        "content": types.Content(
+            role="user" if author == "user" else "model",
+            parts=[types.Part(text=text)],
+        ),
+    }
+    if state is not None:
+        kwargs["state"] = state
+    return Event(**kwargs)
+
+
+def _make_function_call_event(
+    event_id="evt-2",
+    author="agent",
+    fc_id="fc-1",
+    fc_name="get_weather",
+    fc_args=None,
+):
+    """Helper: create ADK Event with function_call part."""
+    if fc_args is None:
+        fc_args = {"city": "Tokyo"}
+    return Event(
+        id=event_id,
+        author=author,
+        content=types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_call=types.FunctionCall(
+                        id=fc_id, name=fc_name, args=fc_args
+                    )
+                )
+            ],
+        ),
+    )
+
+
+def _make_function_response_event(
+    event_id="evt-3",
+    author="agent",
+    fr_id="fc-1",
+    fr_name="get_weather",
+    fr_response=None,
+):
+    """Helper: create ADK Event with function_response part."""
+    if fr_response is None:
+        fr_response = {"temp": 25, "condition": "sunny"}
+    return Event(
+        id=event_id,
+        author=author,
+        content=types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_response=types.FunctionResponse(
+                        id=fr_id, name=fr_name, response=fr_response
+                    )
+                )
+            ],
+        ),
+    )
+
+
+def _make_mixed_event(event_id="evt-4", author="agent"):
+    """Helper: create ADK Event with text + function_call + function_response."""
+    return Event(
+        id=event_id,
+        author=author,
+        content=types.Content(
+            role="model",
+            parts=[
+                types.Part(text="Let me check the weather"),
+                types.Part(
+                    function_call=types.FunctionCall(
+                        id="fc-1", name="get_weather", args={"city": "Tokyo"}
+                    )
+                ),
+                types.Part(
+                    function_response=types.FunctionResponse(
+                        id="fc-1",
+                        name="get_weather",
+                        response={"temp": 25},
+                    )
+                ),
+            ],
+        ),
+    )
+
+
+def _make_state_only_event(event_id="evt-5", author="agent", state=None):
+    """Helper: create ADK Event with no content (state-only)."""
+    kwargs = {
+        "id": event_id,
+        "author": author,
+        "content": None,
+    }
+    if state is not None:
+        kwargs["state"] = state
+    return Event(**kwargs)
+
+
+def _to_message_info(msg, idx=0):
+    """Simulate backend conversion: input message type -> MessageInfo.
+
+    event_to_messages produces TextMessage/ToolCallMessage/ToolResultMessage
+    (input types with .to_dict()), but message_to_event expects MessageInfo
+    (output type with .role and .parts). This helper bridges the gap by
+    calling .to_dict() and constructing a MessageInfo, simulating what the
+    backend would return after persisting the messages.
+    """
+    d = msg.to_dict()
+    # Backend returns meta as dict (not str)
+    meta = None
+    raw_meta = d.get("meta")
+    if raw_meta:
+        if isinstance(raw_meta, str):
+            meta = json.loads(raw_meta)
+        elif isinstance(raw_meta, dict):
+            meta = raw_meta
+    return MessageInfo(
+        id=f"msg-{idx}",
+        session_id="s1",
+        seq=idx,
+        role=d.get("role", "user"),
+        parts=d.get("parts"),
+        meta=meta,
+        message_time=1000 + idx,
+        assistant_id=getattr(msg, "assistant_id", None),
+    )
+
+
+def _messages_to_message_infos(messages):
+    """Convert a list of input message types to MessageInfo list."""
+    return [_to_message_info(msg, i) for i, msg in enumerate(messages)]
+
+
+# ============================================================================
+# TestParseMeta
+# ============================================================================
+
+
+class TestParseMeta:
+    """Tests for _parse_meta helper."""
+
+    def test_none(self):
+        assert _parse_meta(None) == {}
+
+    def test_empty_string(self):
+        assert _parse_meta("") == {}
+
+    def test_json_string(self):
+        assert _parse_meta('{"key": "value"}') == {"key": "value"}
+
+    def test_dict(self):
+        original = {"key": "value"}
+        result = _parse_meta(original)
+        assert result == original
+        # Should return a copy
+        assert result is not original
+
+    def test_non_json_string(self):
+        assert _parse_meta("not json") == {}
+
+    def test_json_array_string(self):
+        """JSON array is valid JSON but not a dict."""
+        assert _parse_meta("[1, 2, 3]") == {}
+
+    def test_empty_json_string(self):
+        assert _parse_meta("{}") == {}
+
+
+# ============================================================================
+# TestExtractSessionScopedState
+# ============================================================================
+
+
+class TestExtractSessionScopedState:
+    """Tests for _extract_session_scoped_state."""
+
+    def test_filters_app_prefix(self):
+        state = {"app:config": "value", "session_key": "keep"}
+        result = _extract_session_scoped_state(state)
+        assert result == {"session_key": "keep"}
+
+    def test_filters_user_prefix(self):
+        state = {"user:preference": "dark", "session_key": "keep"}
+        result = _extract_session_scoped_state(state)
+        assert result == {"session_key": "keep"}
+
+    def test_filters_temp_prefix(self):
+        state = {"temp:cache": "data", "session_key": "keep"}
+        result = _extract_session_scoped_state(state)
+        assert result == {"session_key": "keep"}
+
+    def test_keeps_session_keys(self):
+        state = {"step": 1, "counter": 5, "data": "value"}
+        result = _extract_session_scoped_state(state)
+        assert result == state
+
+    def test_empty_dict(self):
+        assert _extract_session_scoped_state({}) == {}
+
+    def test_mixed_state(self):
+        state = {
+            "current_step": 1,
+            "app:config": "value",
+            "user:preference": "dark",
+            "temp:cache": "data",
+            "session_data": "keep",
+        }
+        result = _extract_session_scoped_state(state)
+        assert result == {"current_step": 1, "session_data": "keep"}
+
+
+# ============================================================================
+# TestEventToMessages
+# ============================================================================
+
+
+class TestEventToMessages:
+    """Tests for event_to_messages."""
+
+    def test_text_event(self):
+        event = _make_text_event()
+        messages = event_to_messages(event)
+        assert len(messages) == 1
+        assert isinstance(messages[0], TextMessage)
+        assert messages[0].role == "user"
+        assert messages[0].content == "Hello"
+
+    def test_function_call_event(self):
+        event = _make_function_call_event()
+        messages = event_to_messages(event)
+        assert len(messages) == 1
+        assert isinstance(messages[0], ToolCallMessage)
+        assert messages[0].id == "fc-1"
+        assert messages[0].name == "get_weather"
+        assert json.loads(messages[0].arguments) == {"city": "Tokyo"}
+
+    def test_function_response_event(self):
+        event = _make_function_response_event()
+        messages = event_to_messages(event)
+        assert len(messages) == 1
+        assert isinstance(messages[0], ToolResultMessage)
+        assert messages[0].tool_call_id == "fc-1"
+        assert json.loads(messages[0].content) == {"temp": 25, "condition": "sunny"}
+
+    def test_mixed_event(self):
+        event = _make_mixed_event()
+        messages = event_to_messages(event)
+        assert len(messages) == 3
+        assert isinstance(messages[0], TextMessage)
+        assert isinstance(messages[1], ToolCallMessage)
+        assert isinstance(messages[2], ToolResultMessage)
+
+    def test_state_only_event_placeholder(self):
+        event = _make_state_only_event()
+        messages = event_to_messages(event)
+        assert len(messages) == 1
+        assert isinstance(messages[0], TextMessage)
+        assert messages[0].content == "[state_update]"
+
+    def test_state_meta_on_last_message(self):
+        """State snapshot should be on the last message."""
+        event = _make_mixed_event()
+        state = {"step": 1, "counter": 5}
+        messages = event_to_messages(event, full_state=state)
+        assert len(messages) == 3
+        # Last message should have state
+        last_meta = json.loads(messages[2].meta)
+        assert _STATE_KEY in last_meta
+        assert last_meta[_STATE_KEY] == state
+        # First two messages should not have state
+        first_meta = json.loads(messages[0].meta)
+        assert _STATE_KEY not in first_meta
+        second_meta = json.loads(messages[1].meta)
+        assert _STATE_KEY not in second_meta
+
+    def test_state_meta_single_message(self):
+        """State snapshot on single message event."""
+        event = _make_text_event()
+        state = {"step": 1}
+        messages = event_to_messages(event, full_state=state)
+        assert len(messages) == 1
+        meta = json.loads(messages[0].meta)
+        assert _STATE_KEY in meta
+        assert meta[_STATE_KEY] == state
+
+    def test_no_state_meta(self):
+        """full_state=None should not add state to meta."""
+        event = _make_text_event()
+        messages = event_to_messages(event, full_state=None)
+        assert len(messages) == 1
+        meta = json.loads(messages[0].meta)
+        assert _STATE_KEY not in meta
+
+    def test_all_messages_carry_event_id(self):
+        """All messages should carry _adk_event_id."""
+        event = _make_mixed_event(event_id="evt-test")
+        messages = event_to_messages(event)
+        for msg in messages:
+            meta = json.loads(msg.meta)
+            assert meta["_adk_event_id"] == "evt-test"
+
+    def test_all_messages_carry_author(self):
+        """All messages should carry _adk_author."""
+        event = _make_mixed_event(author="weather_agent")
+        messages = event_to_messages(event)
+        for msg in messages:
+            meta = json.loads(msg.meta)
+            assert meta["_adk_author"] == "weather_agent"
+
+    def test_tool_result_carry_function_response_name(self):
+        """ToolResultMessage should carry _adk_function_response_name."""
+        event = _make_function_response_event(fr_name="get_weather")
+        messages = event_to_messages(event)
+        assert len(messages) == 1
+        meta = json.loads(messages[0].meta)
+        assert meta["_adk_function_response_name"] == "get_weather"
+
+    def test_to_dict_roundtrip(self):
+        """All message types should serialize via to_dict()."""
+        event = _make_mixed_event()
+        messages = event_to_messages(event)
+        for msg in messages:
+            msg_dict = msg.to_dict()
+            assert isinstance(msg_dict, dict)
+            assert "parts" in msg_dict
+            assert "role" in msg_dict
+
+    def test_state_only_event_carries_author(self):
+        """Placeholder event should also carry _adk_author."""
+        event = _make_state_only_event(author="system_agent")
+        messages = event_to_messages(event)
+        assert len(messages) == 1
+        meta = json.loads(messages[0].meta)
+        assert meta["_adk_author"] == "system_agent"
+
+    def test_user_event_role(self):
+        """User events should have role='user'."""
+        event = _make_text_event(author="user")
+        messages = event_to_messages(event)
+        assert messages[0].role == "user"
+
+    def test_agent_event_role(self):
+        """Agent events should have role='assistant'."""
+        event = _make_text_event(author="agent")
+        messages = event_to_messages(event)
+        assert messages[0].role == "assistant"
+
+
+# ============================================================================
+# TestMessageToEvent
+# ============================================================================
+
+
+class TestMessageToEvent:
+    """Tests for message_to_event."""
+
+    def test_event_id_recovery_from_meta(self):
+        """Event.id should be recovered from _adk_event_id (priority)."""
+        msg = MessageInfo(
+            id="backend-msg-id",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_event_id": "original-evt-id", "_adk_author": "user"}),
+        )
+        event = message_to_event(msg)
+        assert event.id == "original-evt-id"
+
+    def test_event_id_fallback_to_message_id(self):
+        """Event.id should fallback to message.id if no _adk_event_id."""
+        msg = MessageInfo(
+            id="backend-msg-id",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_author": "user"}),
+        )
+        event = message_to_event(msg)
+        assert event.id == "backend-msg-id"
+
+    def test_author_recovery_user_role(self):
+        """User role should always have author='user'."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_event_id": "evt-1"}),
+        )
+        event = message_to_event(msg)
+        assert event.author == "user"
+
+    def test_author_recovery_from_meta(self):
+        """Assistant/agent author should be recovered from _adk_author."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="assistant",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "weather_agent"}),
+        )
+        event = message_to_event(msg)
+        assert event.author == "weather_agent"
+
+    def test_author_fallback_to_assistant_id(self):
+        """Author should fallback to assistant_id if no _adk_author."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="assistant",
+            assistant_id="fallback_agent",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_event_id": "evt-1"}),
+        )
+        event = message_to_event(msg)
+        assert event.author == "fallback_agent"
+
+    def test_text_part_reconstruction(self):
+        """Text part should be reconstructed correctly."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello world"}],
+            meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "user"}),
+        )
+        event = message_to_event(msg)
+        assert event.content is not None
+        assert len(event.content.parts) == 1
+        assert event.content.parts[0].text == "Hello world"
+
+    def test_function_call_reconstruction(self):
+        """FunctionCall should be reconstructed correctly."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="assistant",
+            parts=[
+                {
+                    "type": "tool_call",
+                    "tool_call": {
+                        "id": "fc-1",
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "Tokyo"}),
+                    },
+                }
+            ],
+            meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+        )
+        event = message_to_event(msg)
+        assert event.content is not None
+        assert len(event.content.parts) == 1
+        fc = event.content.parts[0].function_call
+        assert fc.id == "fc-1"
+        assert fc.name == "get_weather"
+        assert fc.args == {"city": "Tokyo"}
+
+    def test_function_response_reconstruction(self):
+        """FunctionResponse should be reconstructed correctly (no double encoding)."""
+        response_data = {"temp": 25, "condition": "sunny"}
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="assistant",
+            parts=[
+                {
+                    "type": "tool_result",
+                    "tool_result": {
+                        "tool_call_id": "fc-1",
+                        "content": json.dumps(response_data),
+                    },
+                }
+            ],
+            meta=json.dumps(
+                {
+                    "_adk_event_id": "evt-1",
+                    "_adk_author": "agent",
+                    "_adk_function_response_name": "get_weather",
+                }
+            ),
+        )
+        event = message_to_event(msg)
+        assert event.content is not None
+        assert len(event.content.parts) == 1
+        fr = event.content.parts[0].function_response
+        assert fr.id == "fc-1"
+        assert fr.name == "get_weather"
+        assert fr.response == response_data  # No double encoding
+
+    def test_function_response_name_recovery(self):
+        """FunctionResponse.name should be recovered from _adk_function_response_name."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="assistant",
+            parts=[
+                {
+                    "type": "tool_result",
+                    "tool_result": {
+                        "tool_call_id": "fc-1",
+                        "content": json.dumps({"result": "ok"}),
+                    },
+                }
+            ],
+            meta=json.dumps(
+                {
+                    "_adk_event_id": "evt-1",
+                    "_adk_author": "agent",
+                    "_adk_function_response_name": "custom_tool",
+                }
+            ),
+        )
+        event = message_to_event(msg)
+        fr = event.content.parts[0].function_response
+        assert fr.name == "custom_tool"
+
+    def test_state_extraction(self):
+        """State should be extracted from _STATE_KEY in meta."""
+        state = {"step": 1, "counter": 5}
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="assistant",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps(
+                {
+                    "_adk_event_id": "evt-1",
+                    "_adk_author": "agent",
+                    _STATE_KEY: state,
+                }
+            ),
+        )
+        event = message_to_event(msg)
+        # State is routed to actions.state_delta via Event model_validator
+        assert event.actions is not None
+        assert event.actions.state_delta == state
+
+    def test_timestamp_conversion(self):
+        """Timestamp should be converted from ms to s."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "user"}),
+            message_time=1609459200000,  # 2021-01-01 00:00:00 UTC in ms
+        )
+        event = message_to_event(msg)
+        assert event.timestamp == 1609459200.0  # Converted to seconds
+
+    def test_content_none_when_no_parts(self):
+        """Content should be None when no parts."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[],
+            meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "user"}),
+        )
+        event = message_to_event(msg)
+        assert event.content is None
+
+    def test_meta_none_handling(self):
+        """Message with meta=None should not crash."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=None,
+        )
+        event = message_to_event(msg)
+        assert event.id == "msg-1"  # Fallback to message.id
+        assert event.author == "user"  # User role
+
+    def test_meta_empty_handling(self):
+        """Message with meta='' should not crash."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta="",
+        )
+        event = message_to_event(msg)
+        assert event.id == "msg-1"
+
+    def test_meta_non_json_handling(self):
+        """Message with non-JSON meta should not crash."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta="not json",
+        )
+        event = message_to_event(msg)
+        assert event.id == "msg-1"
+
+
+# ============================================================================
+# TestMessagesToEvents
+# ============================================================================
+
+
+class TestMessagesToEvents:
+    """Tests for _messages_to_events."""
+
+    def test_consecutive_same_id_grouped(self):
+        """Consecutive messages with same _adk_event_id should be grouped."""
+        msgs = [
+            MessageInfo(
+                id="msg-1",
+                session_id="s1",
+                seq=0,
+                role="assistant",
+                parts=[{"type": "text", "text": "Text"}],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+            ),
+            MessageInfo(
+                id="msg-2",
+                session_id="s1",
+                seq=1,
+                role="assistant",
+                parts=[
+                    {
+                        "type": "tool_call",
+                        "tool_call": {
+                            "id": "fc-1",
+                            "name": "get_weather",
+                            "arguments": json.dumps({"city": "Tokyo"}),
+                        },
+                    }
+                ],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+            ),
+        ]
+        events = _messages_to_events(msgs)
+        assert len(events) == 1
+        assert events[0].id == "evt-1"
+        assert len(events[0].content.parts) == 2
+
+    def test_different_id_split(self):
+        """Messages with different _adk_event_id should be split."""
+        msgs = [
+            MessageInfo(
+                id="msg-1",
+                session_id="s1",
+                seq=0,
+                role="user",
+                parts=[{"type": "text", "text": "Hello"}],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "user"}),
+            ),
+            MessageInfo(
+                id="msg-2",
+                session_id="s1",
+                seq=1,
+                role="assistant",
+                parts=[{"type": "text", "text": "Hi"}],
+                meta=json.dumps({"_adk_event_id": "evt-2", "_adk_author": "agent"}),
+            ),
+        ]
+        events = _messages_to_events(msgs)
+        assert len(events) == 2
+        assert events[0].id == "evt-1"
+        assert events[1].id == "evt-2"
+
+    def test_no_event_id_backward_compat(self):
+        """Messages without _adk_event_id should be treated as individual events."""
+        msgs = [
+            MessageInfo(
+                id="msg-1",
+                session_id="s1",
+                seq=0,
+                role="user",
+                parts=[{"type": "text", "text": "Hello"}],
+                meta=json.dumps({"_adk_author": "user"}),
+            ),
+        ]
+        events = _messages_to_events(msgs)
+        assert len(events) == 1
+        assert events[0].id == "msg-1"  # Fallback to message.id
+
+    def test_empty_list(self):
+        """Empty message list should return empty events list."""
+        events = _messages_to_events([])
+        assert events == []
+
+    def test_trailing_group_flush(self):
+        """Last group should be flushed correctly."""
+        msgs = [
+            MessageInfo(
+                id="msg-1",
+                session_id="s1",
+                seq=0,
+                role="assistant",
+                parts=[{"type": "text", "text": "Text"}],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+            ),
+            MessageInfo(
+                id="msg-2",
+                session_id="s1",
+                seq=1,
+                role="assistant",
+                parts=[
+                    {
+                        "type": "tool_call",
+                        "tool_call": {
+                            "id": "fc-1",
+                            "name": "tool",
+                            "arguments": json.dumps({}),
+                        },
+                    }
+                ],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+            ),
+        ]
+        events = _messages_to_events(msgs)
+        assert len(events) == 1
+        assert len(events[0].content.parts) == 2
+
+
+# ============================================================================
+# TestMergeGroupToEvent
+# ============================================================================
+
+
+class TestMergeGroupToEvent:
+    """Tests for _merge_group_to_event."""
+
+    def test_single_message_path(self):
+        """Single message should go through message_to_event."""
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "user"}),
+        )
+        event = _merge_group_to_event([msg])
+        assert event.id == "evt-1"
+        assert event.author == "user"
+
+    def test_multi_message_path_parts_merge(self):
+        """Multiple messages should merge parts."""
+        msgs = [
+            MessageInfo(
+                id="msg-1",
+                session_id="s1",
+                seq=0,
+                role="assistant",
+                parts=[{"type": "text", "text": "Text"}],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+            ),
+            MessageInfo(
+                id="msg-2",
+                session_id="s1",
+                seq=1,
+                role="assistant",
+                parts=[
+                    {
+                        "type": "tool_call",
+                        "tool_call": {
+                            "id": "fc-1",
+                            "name": "tool",
+                            "arguments": json.dumps({}),
+                        },
+                    }
+                ],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "agent"}),
+            ),
+        ]
+        event = _merge_group_to_event(msgs)
+        assert event.id == "evt-1"
+        assert len(event.content.parts) == 2
+
+    def test_multi_message_path_state_override(self):
+        """Later state should override earlier state."""
+        msgs = [
+            MessageInfo(
+                id="msg-1",
+                session_id="s1",
+                seq=0,
+                role="assistant",
+                parts=[{"type": "text", "text": "Text"}],
+                meta=json.dumps(
+                    {
+                        "_adk_event_id": "evt-1",
+                        "_adk_author": "agent",
+                        _STATE_KEY: {"step": 1},
+                    }
+                ),
+            ),
+            MessageInfo(
+                id="msg-2",
+                session_id="s1",
+                seq=1,
+                role="assistant",
+                parts=[{"type": "text", "text": "More"}],
+                meta=json.dumps(
+                    {
+                        "_adk_event_id": "evt-1",
+                        "_adk_author": "agent",
+                        _STATE_KEY: {"step": 2},
+                    }
+                ),
+            ),
+        ]
+        event = _merge_group_to_event(msgs)
+        assert event.actions.state_delta == {"step": 2}
+
+
+# ============================================================================
+# TestConvertSearchResponse
+# ============================================================================
+
+
+class TestConvertSearchResponse:
+    """Tests for _convert_search_response."""
+
+    def test_results_to_memory_entries(self):
+        """Search results should be converted to MemoryEntry list."""
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.results = [
+            {
+                "record": {"content": "User prefers dark mode", "id": "mem-1"},
+                "score": 0.95,
+            },
+            {
+                "record": {"content": "User likes Python", "id": "mem-2"},
+                "score": 0.88,
+            },
+        ]
+
+        result = _convert_search_response(mock_response)
+        assert len(result.memories) == 2
+        assert result.memories[0].id == "mem-1"
+        assert result.memories[1].id == "mem-2"
+
+    def test_score_to_custom_metadata(self):
+        """Score should be stored in custom_metadata."""
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.results = [
+            {
+                "record": {"content": "Test", "id": "mem-1"},
+                "score": 0.95,
+            }
+        ]
+
+        result = _convert_search_response(mock_response)
+        assert result.memories[0].custom_metadata["score"] == 0.95
+
+
+# ============================================================================
+# TestRoundTrip
+# ============================================================================
+
+
+class TestRoundTrip:
+    """Round-trip fidelity tests (Event -> messages -> Event)."""
+
+    def test_multi_part_event_round_trip(self):
+        """Multi-part Event should survive round-trip."""
+        original = _make_mixed_event(event_id="evt-rt", author="weather_agent")
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        restored = events[0]
+        assert restored.id == "evt-rt"
+        assert restored.author == "weather_agent"
+        assert len(restored.content.parts) == 3
+
+    def test_function_response_name_round_trip(self):
+        """FunctionResponse.name should survive round-trip."""
+        original = _make_function_response_event(fr_name="custom_tool")
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        fr = events[0].content.parts[0].function_response
+        assert fr.name == "custom_tool"
+
+    def test_function_response_response_round_trip(self):
+        """FunctionResponse.response should survive round-trip (no double encoding)."""
+        response_data = {"temp": 25, "condition": "sunny", "nested": {"key": "value"}}
+        original = _make_function_response_event(fr_response=response_data)
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        fr = events[0].content.parts[0].function_response
+        assert fr.response == response_data
+
+    def test_tool_author_round_trip(self):
+        """Tool message author should survive round-trip."""
+        original = _make_mixed_event(author="custom_agent")
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        assert events[0].author == "custom_agent"
+
+    def test_single_part_event_id_round_trip(self):
+        """Single-part Event.id should survive round-trip."""
+        original = _make_text_event(event_id="single-evt")
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        assert events[0].id == "single-evt"
+
+    def test_state_only_event_author_round_trip(self):
+        """State-only event author should survive round-trip."""
+        original = _make_state_only_event(author="system")
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        assert events[0].author == "system"
+
+    def test_user_text_author_round_trip(self):
+        """User text author should survive round-trip."""
+        original = _make_text_event(author="user")
+        messages = event_to_messages(original)
+        infos = _messages_to_message_infos(messages)
+        events = _messages_to_events(infos)
+
+        assert len(events) == 1
+        assert events[0].author == "user"
+
+    def test_backward_compat_no_event_id(self):
+        """Messages without _adk_event_id should be handled correctly."""
+        msg = MessageInfo(
+            id="old-msg-id",
+            session_id="s1",
+            seq=0,
+            role="user",
+            parts=[{"type": "text", "text": "Old message"}],
+            meta=None,
+        )
+        events = _messages_to_events([msg])
+        assert len(events) == 1
+        assert events[0].id == "old-msg-id"
+        assert events[0].author == "user"

--- a/tests/unit/sdk/integration/test_adk_services.py
+++ b/tests/unit/sdk/integration/test_adk_services.py
@@ -1,0 +1,839 @@
+"""
+Unit tests for Google ADK session and memory services.
+
+Tests cover:
+- AgentArtsSessionService (create/get/append/list/delete/fetch)
+- AgentArtsMemoryService (try_add_event/add_session/add_events/search)
+- Module exports
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("google.adk")
+
+from google.adk.events.event import Event
+from google.adk.sessions.session import Session
+from google.genai import types
+
+from agentarts.sdk.integration.google_adk.converter import _STATE_KEY
+from agentarts.sdk.integration.google_adk.memory_service import AgentArtsMemoryService
+from agentarts.sdk.integration.google_adk.session_service import (
+    AgentArtsSessionService,
+)
+from agentarts.sdk.memory import MessageInfo
+
+# --- Helpers ---
+
+
+def _make_mock_client():
+    """Create a mock AsyncMemoryClient."""
+    client = AsyncMock()
+    client.create_memory_session = AsyncMock()
+    client.get_session = AsyncMock()
+    client.get_last_k_messages = AsyncMock(return_value=[])
+    client.list_messages = AsyncMock()
+    client.add_messages = AsyncMock()
+    client.delete_session = AsyncMock()
+    client.list_sessions = AsyncMock()
+    client.search_memories = AsyncMock()
+    return client
+
+
+def _make_session_info(session_id="session-123"):
+    """Create a mock SessionInfo."""
+    info = MagicMock()
+    info.id = session_id
+    return info
+
+
+def _make_message_with_state(state=None, event_id="evt-1"):
+    """Create a MessageInfo with optional state in meta."""
+    meta_dict = {"_adk_event_id": event_id, "_adk_author": "agent"}
+    if state is not None:
+        meta_dict[_STATE_KEY] = state
+    return MessageInfo(
+        id="msg-1",
+        session_id="session-123",
+        seq=0,
+        role="assistant",
+        parts=[{"type": "text", "text": "Hello"}],
+        meta=json.dumps(meta_dict),
+    )
+
+
+def _make_message_list_response(items, total=None):
+    """Create a mock MessageListResponse."""
+    response = MagicMock()
+    response.items = items
+    response.total = total if total is not None else len(items)
+    return response
+
+
+def _make_text_event(event_id="evt-1", author="user", text="Hello"):
+    """Create ADK Event with text part."""
+    return Event(
+        id=event_id,
+        author=author,
+        content=types.Content(
+            role="user" if author == "user" else "model",
+            parts=[types.Part(text=text)],
+        ),
+    )
+
+
+def _make_api_exception(status_code, message="Error"):
+    """Create a real APIException for use as side_effect."""
+    from agentarts.sdk.service import APIException
+
+    return APIException(
+        status_code=status_code,
+        error_code=f"ERR_{status_code}",
+        error_msg=message,
+    )
+
+
+# ============================================================================
+# TestSessionServiceInit
+# ============================================================================
+
+
+class TestSessionServiceInit:
+    """Tests for AgentArtsSessionService initialization."""
+
+    def test_init(self):
+        client = _make_mock_client()
+        service = AgentArtsSessionService(client)
+        assert service._client is client
+
+
+# ============================================================================
+# TestCreateSession
+# ============================================================================
+
+
+class TestCreateSession:
+    """Tests for create_session."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_basic(self):
+        client = _make_mock_client()
+        session_info = _make_session_info("new-session")
+        client.create_memory_session.return_value = session_info
+
+        service = AgentArtsSessionService(client)
+        session = await service.create_session(
+            app_name="test-app",
+            user_id="user-123",
+            state={"key": "value"},
+            session_id="new-session",
+        )
+
+        assert session.id == "new-session"
+        assert session.app_name == "test-app"
+        assert session.user_id == "user-123"
+        assert session.state == {"key": "value"}
+        assert session.events == []
+        client.create_memory_session.assert_called_once_with(
+            space_id="test-app",
+            id="new-session",
+            actor_id="user-123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_session_no_state(self):
+        client = _make_mock_client()
+        session_info = _make_session_info()
+        client.create_memory_session.return_value = session_info
+
+        service = AgentArtsSessionService(client)
+        session = await service.create_session(
+            app_name="test-app",
+            user_id="user-123",
+        )
+
+        assert session.state == {}
+
+
+# ============================================================================
+# TestGetSession
+# ============================================================================
+
+
+class TestGetSession:
+    """Tests for get_session."""
+
+    @pytest.mark.asyncio
+    async def test_get_session_not_found(self):
+        client = _make_mock_client()
+        client.get_session.side_effect = _make_api_exception(404, "Not found")
+
+        service = AgentArtsSessionService(client)
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="nonexistent",
+        )
+
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_get_session_exists(self):
+        client = _make_mock_client()
+        client.get_session.return_value = _make_session_info()
+        client.get_last_k_messages.return_value = []
+        client.list_messages.return_value = _make_message_list_response([])
+
+        service = AgentArtsSessionService(client)
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+        )
+
+        assert session is not None
+        assert session.id == "session-123"
+        assert session.app_name == "test-app"
+        assert session.user_id == "user-123"
+
+    @pytest.mark.asyncio
+    async def test_get_session_state_read(self):
+        client = _make_mock_client()
+        client.get_session.return_value = _make_session_info()
+
+        state = {"step": 1, "counter": 5}
+        msg_with_state = _make_message_with_state(state=state)
+        client.get_last_k_messages.return_value = [msg_with_state]
+        client.list_messages.return_value = _make_message_list_response([])
+
+        service = AgentArtsSessionService(client)
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+        )
+
+        assert session.state == state
+
+    @pytest.mark.asyncio
+    async def test_get_session_state_as_string(self):
+        """State stored as JSON string should be parsed."""
+        client = _make_mock_client()
+        client.get_session.return_value = _make_session_info()
+
+        state = {"step": 1}
+        msg = MessageInfo(
+            id="msg-1",
+            session_id="session-123",
+            seq=0,
+            role="assistant",
+            parts=[{"type": "text", "text": "Hello"}],
+            meta=json.dumps(
+                {
+                    "_adk_event_id": "evt-1",
+                    "_adk_author": "agent",
+                    _STATE_KEY: json.dumps(state),
+                }
+            ),
+        )
+        client.get_last_k_messages.return_value = [msg]
+        client.list_messages.return_value = _make_message_list_response([])
+
+        service = AgentArtsSessionService(client)
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+        )
+
+        assert session.state == state
+
+    @pytest.mark.asyncio
+    async def test_get_session_num_recent_events_zero(self):
+        client = _make_mock_client()
+        client.get_session.return_value = _make_session_info()
+        client.get_last_k_messages.return_value = []
+
+        service = AgentArtsSessionService(client)
+        from google.adk.sessions.base_session_service import GetSessionConfig
+
+        config = GetSessionConfig(num_recent_events=0)
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+            config=config,
+        )
+
+        assert session.events == []
+
+    @pytest.mark.asyncio
+    async def test_get_session_num_recent_events_positive(self):
+        """num_recent_events should over-fetch and trim."""
+        client = _make_mock_client()
+        client.get_session.return_value = _make_session_info()
+
+        # Create 3 events worth of messages (3 events x 2 parts each = 6 messages)
+        messages = []
+        for i in range(3):
+            for j in range(2):
+                messages.append(
+                    MessageInfo(
+                        id=f"msg-{i}-{j}",
+                        session_id="session-123",
+                        seq=i * 2 + j,
+                        role="assistant",
+                        parts=[{"type": "text", "text": f"Event {i} part {j}"}],
+                        meta=json.dumps(
+                            {"_adk_event_id": f"evt-{i}", "_adk_author": "agent"}
+                        ),
+                    )
+                )
+
+        # get_last_k_messages is called twice:
+        # 1. k=1 for state read -> return [] (no state)
+        # 2. k=20 for event loading (fetch_count = 2 * _MAX_PARTS_PER_EVENT = 20)
+        client.get_last_k_messages.side_effect = [[], messages]
+
+        service = AgentArtsSessionService(client)
+        from google.adk.sessions.base_session_service import GetSessionConfig
+
+        config = GetSessionConfig(num_recent_events=2)
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+            config=config,
+        )
+
+        # Should return last 2 events
+        assert len(session.events) == 2
+        assert session.events[0].id == "evt-1"
+        assert session.events[1].id == "evt-2"
+
+    @pytest.mark.asyncio
+    async def test_get_session_after_timestamp(self):
+        client = _make_mock_client()
+        client.get_session.return_value = _make_session_info()
+        client.get_last_k_messages.return_value = []
+
+        # Create messages with different timestamps
+        messages = [
+            MessageInfo(
+                id="msg-1",
+                session_id="session-123",
+                seq=0,
+                role="user",
+                parts=[{"type": "text", "text": "Old"}],
+                meta=json.dumps({"_adk_event_id": "evt-1", "_adk_author": "user"}),
+                message_time=1000000,  # Old timestamp
+            ),
+            MessageInfo(
+                id="msg-2",
+                session_id="session-123",
+                seq=1,
+                role="assistant",
+                parts=[{"type": "text", "text": "New"}],
+                meta=json.dumps({"_adk_event_id": "evt-2", "_adk_author": "agent"}),
+                message_time=2000000,  # New timestamp
+            ),
+        ]
+        client.list_messages.return_value = _make_message_list_response(messages)
+
+        service = AgentArtsSessionService(client)
+        from google.adk.sessions.base_session_service import GetSessionConfig
+
+        config = GetSessionConfig(after_timestamp=1500.0)  # 1500 seconds
+        session = await service.get_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+            config=config,
+        )
+
+        # Only event after timestamp should be included
+        assert len(session.events) == 1
+        assert session.events[0].id == "evt-2"
+
+
+# ============================================================================
+# TestAppendEvent
+# ============================================================================
+
+
+class TestAppendEvent:
+    """Tests for append_event."""
+
+    @pytest.mark.asyncio
+    async def test_append_event_basic(self):
+        client = _make_mock_client()
+        service = AgentArtsSessionService(client)
+
+        session = Session(
+            id="session-123",
+            app_name="test-app",
+            user_id="user-123",
+            state={"step": 1},
+            events=[],
+        )
+        event = _make_text_event(event_id="evt-1")
+
+        result = await service.append_event(session, event)
+
+        assert result is not None
+        client.add_messages.assert_called_once()
+        call_kwargs = client.add_messages.call_args.kwargs
+        assert call_kwargs["space_id"] == "test-app"
+        assert call_kwargs["session_id"] == "session-123"
+        assert call_kwargs["idempotency_key"] == "session-123:evt-1"
+
+    @pytest.mark.asyncio
+    async def test_append_event_state_snapshot(self):
+        """State should be snapshot in messages."""
+        client = _make_mock_client()
+        service = AgentArtsSessionService(client)
+
+        session = Session(
+            id="session-123",
+            app_name="test-app",
+            user_id="user-123",
+            state={"step": 1, "counter": 5},
+            events=[],
+        )
+        event = _make_text_event(event_id="evt-1")
+
+        await service.append_event(session, event)
+
+        messages = client.add_messages.call_args.kwargs["messages"]
+        assert len(messages) > 0
+        # Last message should have state
+        last_meta = json.loads(messages[-1].meta)
+        assert _STATE_KEY in last_meta
+        # State should be session-scoped only (no app:/user:/temp: prefixes)
+        state = last_meta[_STATE_KEY]
+        assert state == {"step": 1, "counter": 5}
+
+    @pytest.mark.asyncio
+    async def test_append_event_409_fallback(self):
+        """409 Conflict should be silently caught."""
+        client = _make_mock_client()
+        client.add_messages.side_effect = _make_api_exception(409, "Conflict")
+
+        service = AgentArtsSessionService(client)
+        session = Session(
+            id="session-123",
+            app_name="test-app",
+            user_id="user-123",
+            state={},
+            events=[],
+        )
+        event = _make_text_event()
+
+        # Should not raise
+        result = await service.append_event(session, event)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_append_event_non_409_raises(self):
+        """Non-409 errors should be re-raised."""
+        client = _make_mock_client()
+        client.add_messages.side_effect = _make_api_exception(500, "Internal error")
+
+        service = AgentArtsSessionService(client)
+        session = Session(
+            id="session-123",
+            app_name="test-app",
+            user_id="user-123",
+            state={},
+            events=[],
+        )
+        event = _make_text_event()
+
+        with pytest.raises(Exception):
+            await service.append_event(session, event)
+
+
+# ============================================================================
+# TestFetchMessages
+# ============================================================================
+
+
+class TestFetchMessages:
+    """Tests for _fetch_messages."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_messages_simple_path(self):
+        """target_count <= 20 should use get_last_k_messages."""
+        client = _make_mock_client()
+        messages = [
+            MessageInfo(
+                id="msg-1",
+                session_id="session-123",
+                seq=0,
+                role="user",
+                parts=[{"type": "text", "text": "Hello"}],
+            )
+        ]
+        client.get_last_k_messages.return_value = messages
+
+        service = AgentArtsSessionService(client)
+        result = await service._fetch_messages("test-app", "session-123", 10)
+
+        assert result == messages
+        client.get_last_k_messages.assert_called_once_with(
+            session_id="session-123", k=10, space_id="test-app"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetch_messages_paginated_path(self):
+        """target_count > 20 should use list_messages with pagination."""
+        client = _make_mock_client()
+
+        # Full dataset of 50 messages; pagination starts at offset 25
+        all_messages = [
+            MessageInfo(
+                id=f"msg-{i}",
+                session_id="session-123",
+                seq=i,
+                role="user",
+                parts=[{"type": "text", "text": f"Message {i}"}],
+            )
+            for i in range(50)
+        ]
+
+        # Mock list_messages to return different pages
+        call_count = [0]
+
+        async def mock_list_messages(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call to get total
+                return _make_message_list_response([], total=50)
+            # Subsequent calls to get pages
+            limit = kwargs.get("limit", 20)
+            offset = kwargs.get("offset", 0)
+            page = all_messages[offset : offset + limit]
+            return _make_message_list_response(page, total=50)
+
+        client.list_messages.side_effect = mock_list_messages
+
+        service = AgentArtsSessionService(client)
+        result = await service._fetch_messages("test-app", "session-123", 25)
+
+        assert len(result) == 25
+
+    @pytest.mark.asyncio
+    async def test_fetch_messages_total_zero(self):
+        """total=0 should return empty list."""
+        client = _make_mock_client()
+        client.list_messages.return_value = _make_message_list_response([], total=0)
+
+        service = AgentArtsSessionService(client)
+        result = await service._fetch_messages("test-app", "session-123", None)
+
+        assert result == []
+
+
+# ============================================================================
+# TestListSessions
+# ============================================================================
+
+
+class TestListSessions:
+    """Tests for list_sessions."""
+
+    @pytest.mark.asyncio
+    async def test_list_sessions(self):
+        client = _make_mock_client()
+
+        session1 = MagicMock()
+        session1.id = "session-1"
+        session1.actor_id = "user-1"
+
+        session2 = MagicMock()
+        session2.id = "session-2"
+        session2.actor_id = "user-1"
+
+        response = MagicMock()
+        response.items = [session1, session2]
+        client.list_sessions.return_value = response
+
+        service = AgentArtsSessionService(client)
+        result = await service.list_sessions(
+            app_name="test-app", user_id="user-1"
+        )
+
+        assert len(result.sessions) == 2
+        assert result.sessions[0].id == "session-1"
+        assert result.sessions[1].id == "session-2"
+
+
+# ============================================================================
+# TestDeleteSession
+# ============================================================================
+
+
+class TestDeleteSession:
+    """Tests for delete_session."""
+
+    @pytest.mark.asyncio
+    async def test_delete_session(self):
+        client = _make_mock_client()
+        service = AgentArtsSessionService(client)
+
+        await service.delete_session(
+            app_name="test-app",
+            user_id="user-123",
+            session_id="session-123",
+        )
+
+        client.delete_session.assert_called_once_with(
+            space_id="test-app", session_id="session-123"
+        )
+
+
+# ============================================================================
+# TestMemoryServiceInit
+# ============================================================================
+
+
+class TestMemoryServiceInit:
+    """Tests for AgentArtsMemoryService initialization."""
+
+    def test_init(self):
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+        assert service._client is client
+
+
+# ============================================================================
+# TestTryAddEvent
+# ============================================================================
+
+
+class TestTryAddEvent:
+    """Tests for _try_add_event."""
+
+    @pytest.mark.asyncio
+    async def test_try_add_event_success(self):
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+
+        event = _make_text_event(event_id="evt-1")
+        await service._try_add_event(event, "session-123", "test-app")
+
+        client.add_messages.assert_called_once()
+        call_kwargs = client.add_messages.call_args.kwargs
+        assert call_kwargs["space_id"] == "test-app"
+        assert call_kwargs["session_id"] == "session-123"
+        assert call_kwargs["idempotency_key"] == "session-123:evt-1"
+        assert call_kwargs["is_force_extract"] is True
+
+    @pytest.mark.asyncio
+    async def test_try_add_event_no_id(self):
+        """Event with empty id should be assigned a UUID."""
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+
+        event = Event(
+            author="user",
+            content=types.Content(
+                role="user", parts=[types.Part(text="Hello")]
+            ),
+        )
+        # Simulate externally constructed Event with no id
+        event.id = ""
+        await service._try_add_event(event, "session-123", "test-app")
+
+        # Should have an id now
+        assert event.id != ""
+        assert event.id is not None
+        client.add_messages.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_try_add_event_no_content_skips(self):
+        """Event with no content should be skipped."""
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+
+        event = Event(id="evt-1", author="agent", content=None)
+        await service._try_add_event(event, "session-123", "test-app")
+
+        client.add_messages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_try_add_event_409_fallback(self):
+        """409 Conflict should be silently caught."""
+        client = _make_mock_client()
+        client.add_messages.side_effect = _make_api_exception(409, "Conflict")
+
+        service = AgentArtsMemoryService(client)
+        event = _make_text_event(event_id="evt-1")
+
+        # Should not raise
+        await service._try_add_event(event, "session-123", "test-app")
+
+    @pytest.mark.asyncio
+    async def test_try_add_event_non_409_raises(self):
+        """Non-409 errors should be re-raised."""
+        client = _make_mock_client()
+        client.add_messages.side_effect = _make_api_exception(500, "Internal error")
+
+        service = AgentArtsMemoryService(client)
+        event = _make_text_event(event_id="evt-1")
+
+        with pytest.raises(Exception):
+            await service._try_add_event(event, "session-123", "test-app")
+
+
+# ============================================================================
+# TestAddSessionToMemory
+# ============================================================================
+
+
+class TestAddSessionToMemory:
+    """Tests for add_session_to_memory."""
+
+    @pytest.mark.asyncio
+    async def test_add_session_to_memory(self):
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+
+        session = Session(
+            id="session-123",
+            app_name="test-app",
+            user_id="user-123",
+            state={},
+            events=[
+                _make_text_event(event_id="evt-1"),
+                _make_text_event(event_id="evt-2"),
+            ],
+        )
+
+        await service.add_session_to_memory(session)
+
+        # Should be called once per event
+        assert client.add_messages.call_count == 2
+
+
+# ============================================================================
+# TestAddEventsToMemory
+# ============================================================================
+
+
+class TestAddEventsToMemory:
+    """Tests for add_events_to_memory."""
+
+    @pytest.mark.asyncio
+    async def test_add_events_to_memory(self):
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+
+        events = [
+            _make_text_event(event_id="evt-1"),
+            _make_text_event(event_id="evt-2"),
+        ]
+
+        await service.add_events_to_memory(
+            app_name="test-app",
+            user_id="user-123",
+            events=events,
+            session_id="session-123",
+        )
+
+        assert client.add_messages.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_add_events_to_memory_default_session_id(self):
+        """Default session_id should be '__unknown_session_id__'."""
+        client = _make_mock_client()
+        service = AgentArtsMemoryService(client)
+
+        events = [_make_text_event(event_id="evt-1")]
+
+        await service.add_events_to_memory(
+            app_name="test-app",
+            user_id="user-123",
+            events=events,
+        )
+
+        call_kwargs = client.add_messages.call_args.kwargs
+        assert call_kwargs["session_id"] == "__unknown_session_id__"
+
+
+# ============================================================================
+# TestSearchMemory
+# ============================================================================
+
+
+class TestSearchMemory:
+    """Tests for search_memory."""
+
+    @pytest.mark.asyncio
+    async def test_search_memory(self):
+        client = _make_mock_client()
+
+        mock_response = MagicMock()
+        mock_response.results = [
+            {
+                "record": {"content": "User prefers dark mode", "id": "mem-1"},
+                "score": 0.95,
+            }
+        ]
+        client.search_memories.return_value = mock_response
+
+        service = AgentArtsMemoryService(client)
+        result = await service.search_memory(
+            app_name="test-app",
+            user_id="user-123",
+            query="user preferences",
+        )
+
+        assert len(result.memories) == 1
+        assert result.memories[0].id == "mem-1"
+        client.search_memories.assert_called_once()
+
+        # Check filter parameters
+        call_kwargs = client.search_memories.call_args.kwargs
+        assert call_kwargs["space_id"] == "test-app"
+        filters = call_kwargs["filters"]
+        assert filters.query == "user preferences"
+        assert filters.actor_id == "user-123"
+
+
+# ============================================================================
+# TestModuleExports
+# ============================================================================
+
+
+class TestModuleExports:
+    """Tests for module exports."""
+
+    def test_import_session_service(self):
+        from agentarts.sdk.integration.google_adk import AgentArtsSessionService
+
+        assert AgentArtsSessionService is not None
+
+    def test_import_memory_service(self):
+        from agentarts.sdk.integration.google_adk import AgentArtsMemoryService
+
+        assert AgentArtsMemoryService is not None
+
+    def test_import_converter_functions(self):
+        from agentarts.sdk.integration.google_adk import (
+            event_to_messages,
+            message_to_event,
+        )
+
+        assert event_to_messages is not None
+        assert message_to_event is not None
+
+    def test_all_exports(self):
+        from agentarts.sdk.integration.google_adk import __all__
+
+        assert "AgentArtsSessionService" in __all__
+        assert "AgentArtsMemoryService" in __all__
+        assert "event_to_messages" in __all__
+        assert "message_to_event" in __all__


### PR DESCRIPTION
## Summary

Add Google ADK (Agent Development Kit) integration module, providing persistent session management and memory services backed by AgentArts Memory.

### File Statistics

| Category | Files | Lines |
|----------|-------|-------|
| Core implementation | `converter.py`, `session_service.py`, `memory_service.py`, `__init__.py` | 913 |
| Unit tests | `test_adk_converter.py`, `test_adk_services.py` | 1,859 |
| Example | `google_adk_agent.py`, `README.md`, `requirements.txt` | 286 |
| **Total** | **11 files** | **3,058** |

### New Module: `src/agentarts/sdk/integration/google_adk/`

| File | Description |
|------|-------------|
| `__init__.py` | Module exports |
| `converter.py` | Bidirectional Event <-> Message conversion with round-trip fidelity |
| `session_service.py` | `AgentArtsSessionService` implementing ADK `BaseSessionService` |
| `memory_service.py` | `AgentArtsMemoryService` implementing ADK `BaseMemoryService` |

### Architecture

```
Google ADK Runtime                  AgentArts Backend
┌──────────────────────┐           ┌─────────────────────────┐
│  Agent + Tools       │           │  Memory Service         │
│  (LLM-driven)        │           │  (spaces, sessions,     │
│                      │           │   messages, search)     │
└──────────┬───────────┘           └────────────┬────────────┘
           │                                     │
┌──────────┴─────────────────────────────────────┴────────────┐
│                      ADK Runner                              │
│                                                              │
│  ┌─────────────────────────┐  ┌───────────────────────────┐ │
│  │ AgentArtsSessionService │  │ AgentArtsMemoryService    │ │
│  │                         │  │                           │ │
│  │ create_session ───────────► create_memory_session       │ │
│  │ get_session ──────────────► get_session + get_messages  │ │
│  │ append_event ─────────────► add_messages (idempotent)   │ │
│  │ list_sessions ────────────► list_sessions               │ │
│  │ delete_session ───────────► delete_session              │ │
│  └─────────────────────────┘  │                           │ │
│                               │ add_session_to_memory ──────► add_messages │
│                               │ search_memory ─────────────► search_memories│
│                               └───────────────────────────┘ │
│                                                              │
│  ┌─────────────────────────────────────────────────────────┐ │
│  │ converter.py                                            │ │
│  │  event_to_messages()  ── Event → Message[] + state meta │ │
│  │  _messages_to_events()── Message[] → Event (grouped)    │ │
│  │  _convert_search_response() ── MemorySearch → ADK resp  │ │
│  └─────────────────────────────────────────────────────────┘ │
└──────────────────────────────────────────────────────────────┘
```

### Concept Mapping

| ADK Concept | AgentArts Concept | Notes |
|-------------|-------------------|-------|
| `app_name` | `space_id` | Top-level namespace |
| `user_id` | `actor_id` | End-user identity |
| `session_id` | `session_id` | Conversation scope |
| `Session.events` | `messages` | Ordered event log |
| `Session.state` | `message.meta[_STATE_KEY]` | Full snapshot in last message |
| `Event.content.parts` | `message.content` (JSON array) | Each part → one message |
| `FunctionCall` / `FunctionResponse` | `tool_use` / `tool_result` blocks | Structured as JSON in message content |

### API Coverage

All abstract methods of `BaseSessionService` and `BaseMemoryService` are implemented:

| BaseSessionService Method | Implementation | Key Behavior |
|--------------------------|----------------|--------------|
| `create_session` | ✅ | Creates memory session, returns empty Session |
| `get_session` | ✅ | O(1) state read via `get_last_k_messages(k=1)`; paginated event loading |
| `list_sessions` | ✅ | Delegates to `client.list_sessions` |
| `delete_session` | ✅ | Delegates to `client.delete_session` |
| `append_event` | ✅ | Base class state update → full snapshot → idempotency-key persist |

| BaseMemoryService Method | Implementation | Key Behavior |
|--------------------------|----------------|--------------|
| `add_session_to_memory` | ✅ | Iterates all events, each with idempotency key |
| `add_events_to_memory` | ✅ | Incremental delta ingestion |
| `search_memory` | ✅ | `MemorySearchFilter(query, actor_id)` → ADK `SearchMemoryResponse` |

### Converter Capabilities

`converter.py` handles bidirectional Event ↔ Message conversion with round-trip fidelity:

- **Event → Messages**: Each `Content.part` becomes a separate message. Supports `TextPart`, `FunctionCall`, `FunctionResponse` (including nested dict/list response values).
- **Messages → Events**: Messages sharing the same `event_id` (stored in `meta`) are grouped back into a single Event with multiple parts.
- **State snapshot**: `event_to_messages(event, full_state=...)` embeds the complete session-scoped state dict into each message's `meta[_STATE_KEY]`.
- **Metadata preservation**: `Event.id`, `Event.author`, `Event.timestamp`, `FunctionResponse.name` are all preserved through the conversion round-trip.
- **Scope filtering**: `_extract_session_scoped_state` strips `app:`, `user:`, and `temp:` prefixed keys, persisting only `session:`-scoped state.

### Key Design Decisions

1. **State persistence (full snapshot)**: Each `append_event` stores the complete session-scoped state in `message.meta` under `_STATE_KEY`. Reading state requires only `get_last_k_messages(k=1)` - O(1) complexity.
2. **Deduplication**: `idempotency_key=f"{session_id}:{event.id}"` with 409 Conflict fallback ensures no duplicates when both SessionService and MemoryService persist the same event.
3. **Async extraction alignment**: MemoryService uses `is_force_extract=True` (safe, non-blocking) and prefers incremental `add_events_to_memory` over full `add_session_to_memory`.
4. **Lazy imports**: ADK classes are lazy-loaded with friendly error messages when `google-adk` is not installed.

### Data Flow: Single Conversation Turn

```
User message ──► ADK Runner
                    │
                    ├─► Agent (LLM call)
                    │     │
                    │     ▼
                    │   Event (content + tool calls + state delta)
                    │
                    └─► SessionService.append_event(session, event)
                          │
                          ├─ 1. super().append_event() → in-memory state update
                          ├─ 2. _extract_session_scoped_state(session.state)
                          ├─ 3. event_to_messages(event, full_state=state)
                          │      → Message[] with meta[_STATE_KEY] = full snapshot
                          └─ 4. client.add_messages(
                                   idempotency_key="{session_id}:{event.id}"
                                 )
                                 │
                                 ├─ 200 OK → persisted
                                 └─ 409 Conflict → already persisted, skip

               ──► MemoryService.add_events_to_memory(events=[event])
                     │
                     └─ client.add_messages(
                            idempotency_key="{session_id}:{event.id}",
                            is_force_extract=True
                          )
                          │
                          ├─ 200 OK → persisted + extraction triggered
                          └─ 409 Conflict → already persisted, skip
```

Note: Both `SessionService.append_event` and `MemoryService.add_events_to_memory` use the **same idempotency key** for the same event. This is the core dedup mechanism — the second call is always a no-op.

### Error Handling

| Scenario | Behavior |
|----------|----------|
| Session not found (404) | `get_session` returns `None` |
| Duplicate event (409) | Silently skipped — idempotency key ensures no-op |
| Missing `google-adk` package | Friendly `ImportError` with install instructions at import time |
| Empty event (no content parts) | Skipped by MemoryService (no message to persist) |
| `event.id` is `None` | Auto-assigned UUID to avoid idempotency key collision |

### Limitations

- **State scope**: Only `session:`-scoped state is persisted. `user:` and `app:` scoped state are silently dropped, as AgentArts Memory is organized by space/session, not by user or app globally.
- **Event reconstruction**: When loading events from messages, each `Content.part` becomes a separate message. Events with multiple parts are reconstructed by grouping messages with the same `event_id` in `meta`. This is transparent to the caller but means the internal storage model differs from ADK's in-memory model.
- **Memory extraction**: The AgentArts backend performs memory extraction asynchronously. Calling `add_session_to_memory` or `add_events_to_memory` triggers extraction, but the extracted memories may not be immediately available for `search_memory`. This is by design and aligns with the backend's non-blocking philosophy.

### Quick Start & Example

```python
from agentarts.sdk.memory import AsyncMemoryClient
from agentarts.sdk.integration.google_adk import (
    AgentArtsSessionService,
    AgentArtsMemoryService,
)
from google.adk.agents import Agent
from google.adk.runners import Runner

# 1. Create the AgentArts client
client = AsyncMemoryClient(api_key="your-api-key", space_id="your-space-id")

# 2. Create ADK services backed by AgentArts
session_service = AgentArtsSessionService(client)
memory_service = AgentArtsMemoryService(client)

# 3. Create an ADK Agent with tools
agent = Agent(
    name="assistant",
    model="openai/gpt-4o-mini",
    tools=[your_tool],
    generate_content_config=...,  # optional: model-specific config
)

# 4. Run with Runner
runner = Runner(
    agent=agent,
    session_service=session_service,
    memory_service=memory_service,
    auto_create_session=True,
)

session = await session_service.create_session(
    app_name="my-app", user_id="user-1"
)
async for event in runner.run_async(
    user_id="user-1", session_id=session.id, message=user_message
):
    print(event.content)
```

A full working example is available at `examples/integration/google_adk/` — a multi-turn conversation demo with calculator and time tools.

### Dependencies

- `pyproject.toml` — Added `google-adk>=2.0.0` as optional dependency under `[project.optional-dependencies]` and included it in the `all` extra

### Testing & Verification

All tests use `unittest.mock` to mock the `AsyncMemoryClient` — no real network calls are made.

| Test file | Tests | Mock target | Coverage |
|-----------|-------|-------------|----------|
| `test_adk_converter.py` | 61 | None (pure functions) | `parse_meta`, state extraction, event↔message conversion, round-trip fidelity |
| `test_adk_services.py` | 33 | `AsyncMemoryClient` | Session CRUD, `append_event`, pagination, 409 dedup, memory ingestion, search |

**94 tests, all passing.**

Key testing patterns:
- **Round-trip tests**: `Event → messages → Event` preserves all fields
- **Boundary tests**: Empty events, `None` event IDs, events with no content parts
- **Pagination tests**: Mock `list_messages` with `total > limit` to verify multi-page fetching
- **Dedup tests**: Verify 409 is caught and logged, not raised

**Integration demo** (multi-turn conversation with tools):
- 4-turn conversation exercising tool calling (`calculate`, `get_current_time`), session persistence, and conversation memory recall
- Verified `idempotency_key` dedup: re-adding the same session does not create duplicate messages
- Verified reasoning model compatibility: `generate_content_config` with `thinking.type=disabled` prevents `Missing reasoning_content` errors across multiple turns

### Review Guide

For a PR of this size, here is a suggested review order:

1. **`converter.py`** (417 lines) — Core data model. Start here to understand how ADK Events map to AgentArts Messages. All other components depend on this.
2. **`session_service.py`** (307 lines) — Session lifecycle. Key methods: `get_session` (state recovery), `append_event` (write path with dedup).
3. **`memory_service.py`** (155 lines) — Memory ingestion. Relatively small; builds on converter.
4. **`__init__.py`** (34 lines) — Lazy import registration. Quick check.
5. **`pyproject.toml`** (2 changes) — Optional dependency addition.
6. **Tests** (1,859 lines) — Can be reviewed in parallel or skimmed for coverage gaps.
7. **Example** (286 lines) — End-to-end usage; confirms the public API shape.

### Comparison with LangGraph Integration

| Aspect | LangGraph (`MemorySessionSaver`) | Google ADK (`SessionService` + `MemoryService`) |
|--------|----------------------------------|--------------------------------------------------|
| Framework | LangGraph `StateGraph` | ADK `Runner` + `Agent` |
| Session persistence | `AsyncSqliteSaver` replacement | `BaseSessionService` implementation |
| State management | Checkpoint (full graph state) | Session state (full snapshot in meta) |
| Dedup strategy | Checkpoint-based | `idempotency_key` + 409 fallback |
| Event model | Direct message storage | Event ↔ Message conversion layer |
| Tool calling | Via LangGraph nodes | Native ADK tool support |