### PR TITLE
feat(sdk): append SDK version and OS info to User-Agent header

### DIFF
--- a/src/agentarts/sdk/service/http_client.py
+++ b/src/agentarts/sdk/service/http_client.py
@@ -24,6 +24,7 @@ from typing_extensions import Self
 
 from agentarts.sdk.utils.signer import SDKSigner
 from agentarts.sdk.utils.signer_v11 import V11Signer
+from agentarts.sdk.utils.user_agent import build_user_agent
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,8 @@ class BaseHTTPClient:
         self._config = config or RequestConfig()
         self._session = requests.Session()
         self._session.headers.update(self._config.headers)
+        original_ua = self._session.headers.get("User-Agent", "")
+        self._session.headers["User-Agent"] = build_user_agent(original_ua)
         self._open_ak_sk = open_ak_sk
         self._sign_mode = sign_mode
         self._region_id = region_id

--- a/src/agentarts/sdk/service/identity/identity_client.py
+++ b/src/agentarts/sdk/service/identity/identity_client.py
@@ -25,6 +25,7 @@ from agentarts.sdk.service.identity.polling.token_poller import (
     TokenPoller,
 )
 from agentarts.sdk.utils.constant import get_identity_endpoint
+from agentarts.sdk.utils.user_agent import build_user_agent
 from huaweicloudsdkagentidentity.v1 import (
     AgentIdentityClient,
     ApiKeyCredentialProvider,
@@ -127,6 +128,7 @@ class IdentityClient:
         # Set HTTP configuration
         http_config = HttpConfig.get_default_config()
         http_config.ignore_ssl_verification = ignore_ssl_verification
+        http_config.user_agent = build_user_agent()
 
         # Initialize clients using builder pattern
         if client is not None:

--- a/src/agentarts/sdk/service/memory_service.py
+++ b/src/agentarts/sdk/service/memory_service.py
@@ -13,6 +13,7 @@ import requests
 
 from agentarts.sdk.utils.constant import get_memory_endpoint, get_region
 from agentarts.sdk.utils.signer import SDKSigner
+from agentarts.sdk.utils.user_agent import build_user_agent
 
 from .http_client import APIException
 
@@ -76,7 +77,6 @@ class DataPlaneAuthenticationStrategy(AuthenticationStrategy):
         """Get headers with API_KEY authentication."""
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "agentarts-sdk-python/0.0.1",
         }
 
         api_key = self._api_key or os.getenv("HUAWEICLOUD_SDK_MEMORY_API_KEY")
@@ -142,7 +142,6 @@ class ControlPlaneAuthenticationStrategy(AuthenticationStrategy):
         """Get base headers for control plane requests."""
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "agentarts-sdk/0.0.1",
         }
 
         if hasattr(self, "client_request_id"):
@@ -240,6 +239,8 @@ class MemoryHttpService:
             self._enable_signing = enable_signing
 
         self.session = requests.Session()
+        original_ua = self.session.headers.get("User-Agent", "")
+        self.session.headers["User-Agent"] = build_user_agent(original_ua)
 
         self._auth_strategy = self._create_authentication_strategy(endpoint_type)
 

--- a/src/agentarts/sdk/service/memory_service_async.py
+++ b/src/agentarts/sdk/service/memory_service_async.py
@@ -15,6 +15,7 @@ import httpx
 
 from agentarts.sdk.utils.constant import get_memory_endpoint, get_region
 from agentarts.sdk.utils.signer import SDKSigner
+from agentarts.sdk.utils.user_agent import build_user_agent
 
 from .http_client import APIException
 
@@ -41,7 +42,6 @@ class AsyncDataPlaneAuthenticationStrategy:
         """Get headers with API_KEY authentication - identical to sync version."""
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "agentarts-sdk-python/0.0.1",
         }
 
         api_key = self._api_key or os.getenv("HUAWEICLOUD_SDK_MEMORY_API_KEY")
@@ -109,7 +109,6 @@ class AsyncControlPlaneAuthenticationStrategy:
         """Get base headers for control plane requests - identical to sync version."""
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "agentarts-sdk/0.0.1",
         }
 
         if hasattr(self, "client_request_id"):
@@ -227,6 +226,8 @@ class AsyncMemoryHttpService:
                 timeout=httpx.Timeout(self.timeout),
                 verify=verify,
             )
+            original_ua = self._async_client.headers.get("User-Agent", "")
+            self._async_client.headers["User-Agent"] = build_user_agent(original_ua)
         return self._async_client
 
     async def _make_request(

--- a/src/agentarts/sdk/utils/user_agent.py
+++ b/src/agentarts/sdk/utils/user_agent.py
@@ -1,0 +1,42 @@
+"""User-Agent construction utilities.
+
+Builds a User-Agent suffix of the form
+``os/<system>/<release> agentarts-sdk-python/<version>`` and appends it to an
+existing value rather than replacing it.
+"""
+
+import platform
+from importlib.metadata import PackageNotFoundError, version
+
+SDK_DISTRIBUTION = "agentarts-sdk"
+SDK_PRODUCT = "agentarts-sdk-python"
+_FALLBACK_VERSION = "0.1.0"
+
+
+def get_sdk_version() -> str:
+    """Return the installed SDK version from package metadata."""
+    try:
+        return version(SDK_DISTRIBUTION)
+    except PackageNotFoundError:
+        return _FALLBACK_VERSION
+
+
+def get_os_metadata() -> str:
+    """Return the operating system metadata in ``os/<system>/<release>`` form."""
+    return f"os/{platform.system()}/{platform.release()}"
+
+
+def build_user_agent(original: str | None = None) -> str:
+    """Append the SDK version and OS metadata to an existing User-Agent.
+
+    Args:
+        original: The pre-existing User-Agent value to preserve. When omitted,
+            the returned string contains only the SDK version and OS metadata.
+
+    Returns:
+        A combined User-Agent string.
+    """
+    suffix = f"{get_os_metadata()} {SDK_PRODUCT}/{get_sdk_version()}"
+    if original:
+        return f"{original} {suffix}"
+    return suffix

--- a/tests/unit/sdk/utils/test_user_agent.py
+++ b/tests/unit/sdk/utils/test_user_agent.py
@@ -1,0 +1,57 @@
+"""
+Unit tests for User-Agent construction utilities
+"""
+
+from importlib.metadata import PackageNotFoundError
+
+from agentarts.sdk.utils.user_agent import (
+    build_user_agent,
+    get_os_metadata,
+    get_sdk_version,
+)
+
+
+def _raise_package_not_found(_name: str) -> str:
+    raise PackageNotFoundError()
+
+
+class TestUserAgent:
+    """Test User-Agent construction utilities"""
+
+    def test_get_sdk_version_is_not_placeholder(self):
+        """Version should come from package metadata, not the 0.0.1 placeholder."""
+        assert get_sdk_version() != "0.0.1"
+
+    def test_get_sdk_version_fallback(self, monkeypatch):
+        """Fallback version is returned when the package is not installed."""
+        import agentarts.sdk.utils.user_agent as ua_module
+
+        monkeypatch.setattr(ua_module, "version", _raise_package_not_found)
+        assert get_sdk_version() == "0.1.0"
+
+    def test_get_os_metadata_format(self):
+        """OS metadata uses the os/<system>/<release> format."""
+        meta = get_os_metadata()
+        assert meta.startswith("os/")
+        assert meta.count("/") == 2
+
+    def test_build_user_agent_without_original(self):
+        """Without an original value, output is exactly os metadata + version."""
+        assert build_user_agent() == (
+            f"{get_os_metadata()} agentarts-sdk-python/{get_sdk_version()}"
+        )
+
+    def test_build_user_agent_preserves_original(self):
+        """The original User-Agent value is preserved, not replaced."""
+        original = "python-requests/2.31.0"
+        ua = build_user_agent(original)
+        assert ua == (
+            f"{original} {get_os_metadata()} agentarts-sdk-python/{get_sdk_version()}"
+        )
+
+    def test_build_user_agent_ordering(self):
+        """Format is <original> os/<system>/<release> agentarts-sdk-python/<version>."""
+        ua = build_user_agent("python-requests/2.31.0")
+        assert ua.startswith("python-requests/2.31.0 os/")
+        assert " agentarts-sdk-python/" in ua
+        assert ua.count("agentarts-sdk-python/") == 1


### PR DESCRIPTION
## Summary
Append the SDK version and OS info to the `User-Agent` header for all outbound HTTP requests, without overwriting the existing value.

Final format: `<original> os/<system>/<release> agentarts-sdk-python/<version>`

## Changes
- Add `agentarts.sdk.utils.user_agent` helper (`build_user_agent`, `get_sdk_version`, `get_os_metadata`).
- `BaseHTTPClient` (runtime / code interpreter / gateway): append to the requests default UA.
- `MemoryHttpService` / `AsyncMemoryHttpService`: replace the hardcoded `0.0.1` UA and append to the session/client default UA.
- `IdentityClient`: set `HttpConfig.user_agent` so the Huawei Cloud SDK appends the version + OS info.
- Add unit tests (100% coverage on the new module).

## Test plan
- [x] `pytest tests/unit/sdk/utils/test_user_agent.py` passes (100% coverage)
- [x] Verified actual request headers via a local echo server: `python-requests/2.33.1 os/Windows/11 agentarts-sdk-python/0.1.4.dev72801`