### PR TITLE
fix(service): correct network error classification in memory HTTP clients and make delete_thread cleanup robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `MemoryAPIException` exported from `agentarts.sdk.service`, with `is_network_error` / `retryable` helper properties
+
+### Fixed
+- Network errors in memory HTTP clients no longer reported as HTTP 503; they now use `status_code=0` (no server response) with the original exception preserved via `__cause__`
+- 2xx responses with non-JSON bodies are now classified as `PARSE_ERROR` instead of being mislabeled as network errors
+- `delete_thread` / `adelete_thread` now clean up the persisted-count tracking even when session deletion fails (via `try/finally`)
+
 ## [0.1.3] - 2026-06-06
 
 ### Added

--- a/src/agentarts/sdk/integration/langgraph/saver.py
+++ b/src/agentarts/sdk/integration/langgraph/saver.py
@@ -650,27 +650,31 @@ class AgentArtsMemorySessionSaver(BaseCheckpointSaver):
         Args:
             thread_id: Thread ID (= session ID) to delete
         """
-        try:
-            self._client.delete_session(
-                space_id=self._space_id,
-                session_id=thread_id,
-            )
-        except Exception as e:
-            logger.exception(f"Failed to delete session for thread {thread_id}: {e}")
-
-        # Also delete the writes session
         writes_sid = self._writes_session_id(thread_id)
         try:
-            self._client.delete_session(
-                space_id=self._space_id,
-                session_id=writes_sid,
-            )
-        except Exception as e:
             # Writes session may not exist — log at debug level
-            logger.debug(f"Failed to delete writes session for thread {thread_id}: {e}")
+            try:
+                self._client.delete_session(
+                    space_id=self._space_id,
+                    session_id=writes_sid,
+                )
+            except Exception as e:
+                logger.debug(
+                    f"Failed to delete writes session for thread {thread_id}: {e}"
+                )
 
-        # Clean up persisted count tracking
-        self._persisted_count.pop(thread_id, None)
+            try:
+                self._client.delete_session(
+                    space_id=self._space_id,
+                    session_id=thread_id,
+                )
+            except Exception as e:
+                logger.exception(
+                    f"Failed to delete session for thread {thread_id}: {e}"
+                )
+        finally:
+            # Clean up persisted count tracking regardless of outcome
+            self._persisted_count.pop(thread_id, None)
 
     def close(self) -> None:
         """
@@ -1076,21 +1080,28 @@ class AgentArtsMemorySessionSaver(BaseCheckpointSaver):
         Args:
             thread_id: Thread ID (= session ID) to delete
         """
-        try:
-            await self._async_client.delete_session(
-                space_id=self._space_id,
-                session_id=thread_id,
-            )
-        except Exception as e:
-            logger.exception(f"Failed to delete session for thread {thread_id}: {e}")
-
         writes_sid = self._writes_session_id(thread_id)
         try:
-            await self._async_client.delete_session(
-                space_id=self._space_id,
-                session_id=writes_sid,
-            )
-        except Exception as e:
-            logger.debug(f"Failed to delete writes session for thread {thread_id}: {e}")
+            # Writes session may not exist — log at debug level
+            try:
+                await self._async_client.delete_session(
+                    space_id=self._space_id,
+                    session_id=writes_sid,
+                )
+            except Exception as e:
+                logger.debug(
+                    f"Failed to delete writes session for thread {thread_id}: {e}"
+                )
 
-        self._persisted_count.pop(thread_id, None)
+            try:
+                await self._async_client.delete_session(
+                    space_id=self._space_id,
+                    session_id=thread_id,
+                )
+            except Exception as e:
+                logger.exception(
+                    f"Failed to delete session for thread {thread_id}: {e}"
+                )
+        finally:
+            # Clean up persisted count tracking regardless of outcome
+            self._persisted_count.pop(thread_id, None)

--- a/src/agentarts/sdk/service/__init__.py
+++ b/src/agentarts/sdk/service/__init__.py
@@ -7,6 +7,7 @@ Provides base HTTP client for API calls.
 from agentarts.sdk.service.http_client import (
     APIException,
     BaseHTTPClient,
+    MemoryAPIException,
     RequestConfig,
     RequestResult,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "BaseHTTPClient",
     "IAMClient",
     "LocalRuntimeClient",
+    "MemoryAPIException",
     "RequestConfig",
     "RequestResult",
     "RuntimeClient",

--- a/src/agentarts/sdk/service/http_client.py
+++ b/src/agentarts/sdk/service/http_client.py
@@ -40,6 +40,27 @@ class APIException(Exception):
         super().__init__(f"[{error_code}] HTTP {status_code}: {error_msg}")
 
 
+class MemoryAPIException(APIException):
+    """Custom exception for Memory API errors.
+
+    分类约定：
+    - 网络错误：status_code=0, error_code="NETWORK_ERROR"（请求未获得服务器响应）。
+    - 解析错误：status_code 为实际 HTTP 状态码, error_code="PARSE_ERROR"
+      （2xx 但响应体非合法 JSON）。
+    - 服务端错误：status_code 为实际 HTTP 状态码。
+    """
+
+    @property
+    def is_network_error(self) -> bool:
+        """True 表示请求未获得服务器响应（网络层故障）。"""
+        return self.status_code == 0 and self.error_code == "NETWORK_ERROR"
+
+    @property
+    def retryable(self) -> bool:
+        """是否建议重试：网络错误、429 限流、5xx 服务端错误。"""
+        return self.is_network_error or self.status_code in (429, 500, 502, 503, 504)
+
+
 class SignMode(Enum):
     """Signature mode for AK/SK authentication."""
 

--- a/src/agentarts/sdk/service/memory_service.py
+++ b/src/agentarts/sdk/service/memory_service.py
@@ -14,7 +14,7 @@ import requests
 from agentarts.sdk.utils.constant import get_memory_endpoint, get_region
 from agentarts.sdk.utils.signer import SDKSigner
 
-from .http_client import APIException
+from .http_client import APIException, MemoryAPIException
 
 logger = logging.getLogger(__name__)
 
@@ -188,10 +188,6 @@ class ControlPlaneAuthenticationStrategy(AuthenticationStrategy):
         )
 
 
-class MemoryAPIException(APIException):
-    """Custom exception for Memory API errors."""
-
-
 class MemoryHttpService:
     """HTTP client for Huawei Memory API operations with AK/SK authentication.
 
@@ -337,7 +333,15 @@ class MemoryHttpService:
 
             if response.status_code in {200, 201}:
                 if response.headers.get("content-type", "").startswith("application/json"):
-                    return response.json()
+                    try:
+                        return response.json()
+                    except ValueError as e:  # 覆盖 requests.exceptions.JSONDecodeError
+                        # 2xx 但响应体非合法 JSON：解析错误，区别于网络错误
+                        raise MemoryAPIException(
+                            status_code=response.status_code,
+                            error_code="PARSE_ERROR",
+                            error_msg=f"Failed to parse JSON response: {e}",
+                        ) from e
                 return {"response": response.text}
             if response.status_code == 204:
                 return {}
@@ -358,12 +362,12 @@ class MemoryHttpService:
         except Exception as e:
             if isinstance(e, MemoryAPIException):
                 raise
-            logger.exception(f"HTTP request failed: {e}")
+            logger.warning(f"Network request failed: {e}")
             raise MemoryAPIException(
-                status_code=503,
+                status_code=0,  # 0 = 无 HTTP 响应（对齐 BaseHTTPClient 先例）
                 error_code="NETWORK_ERROR",
-                error_msg=str(e)
-            )
+                error_msg=str(e),
+            ) from e  # 保留原始异常链，用户可访问 e.__cause__
 
     def create_space(self, data: dict[str, Any]) -> dict[str, Any]:
         """Create a new memory space.

--- a/src/agentarts/sdk/service/memory_service_async.py
+++ b/src/agentarts/sdk/service/memory_service_async.py
@@ -16,13 +16,9 @@ import httpx
 from agentarts.sdk.utils.constant import get_memory_endpoint, get_region
 from agentarts.sdk.utils.signer import SDKSigner
 
-from .http_client import APIException
+from .http_client import APIException, MemoryAPIException
 
 logger = logging.getLogger(__name__)
-
-
-class MemoryAPIException(APIException):
-    """Custom exception for Memory API errors."""
 
 
 class AsyncDataPlaneAuthenticationStrategy:
@@ -289,7 +285,15 @@ class AsyncMemoryHttpService:
 
             if response.status_code in {200, 201}:
                 if response.headers.get("content-type", "").startswith("application/json"):
-                    return response.json()
+                    try:
+                        return response.json()
+                    except ValueError as e:  # 覆盖 json.JSONDecodeError
+                        # 2xx 但响应体非合法 JSON：解析错误，区别于网络错误
+                        raise MemoryAPIException(
+                            status_code=response.status_code,
+                            error_code="PARSE_ERROR",
+                            error_msg=f"Failed to parse JSON response: {e}",
+                        ) from e
                 return {"response": response.text}
             if response.status_code == 204:
                 return {}
@@ -310,12 +314,12 @@ class AsyncMemoryHttpService:
         except Exception as e:
             if isinstance(e, MemoryAPIException):
                 raise
-            logger.exception(f"HTTP request failed: {e}")
+            logger.warning(f"Network request failed: {e}")
             raise MemoryAPIException(
-                status_code=503,
+                status_code=0,  # 0 = 无 HTTP 响应（对齐 BaseHTTPClient 先例）
                 error_code="NETWORK_ERROR",
-                error_msg=str(e)
-            )
+                error_msg=str(e),
+            ) from e  # 保留原始异常链，用户可访问 e.__cause__
 
     async def create_space(self, data: dict[str, Any]) -> dict[str, Any]:
         """Create a new memory space - identical to sync version."""

--- a/tests/unit/sdk/integration/test_saver_writes_delete_list.py
+++ b/tests/unit/sdk/integration/test_saver_writes_delete_list.py
@@ -1,0 +1,530 @@
+"""
+Unit tests for AgentArtsMemorySessionSaver behavior.
+
+Migrated from my_simple_demo/test_saver_writes_delete_list.py (which is
+git-ignored) into the formal unit test suite. Covers the actual behavior of:
+- put_writes / aput_writes (storage, 404 auto-create retry, dedup)
+- get_tuple / aget_tuple and list / alist (pending_writes extraction)
+- delete_thread / adelete_thread (order, swallow contract, cleanup)
+- context managers (sync / async close behavior)
+
+Uses in-memory fake clients (no real API calls).
+"""
+
+import asyncio
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+from agentarts.sdk.integration.langgraph import AgentArtsMemorySessionSaver
+from agentarts.sdk.service.http_client import APIException
+
+
+class FakeMessage:
+    """Mock message for testing."""
+
+    def __init__(self, role, content="", meta=None):
+        self.role = role
+        self.content = content
+        self.meta = meta
+        # parts is what memory_to_langgraph_message expects
+        self.parts = [{"type": "text", "text": content}]
+
+
+class FakeMemoryClient:
+    """In-memory mock of MemoryClient for testing."""
+
+    def __init__(self):
+        self.sessions = {}  # session_id -> list of message objects
+        self.add_messages_calls = []
+        self.delete_session_calls = []
+        self.create_memory_session_calls = []
+        self.close_called = False
+        self._add_messages_fail_404 = False
+        self._delete_session_fail = False
+        self.delete_session_attempts = 0
+
+    def add_messages(self, space_id, session_id, messages):
+        # Simulate 404 on first call if flag is set
+        if self._add_messages_fail_404:
+            self._add_messages_fail_404 = False
+            raise APIException(404, "NotFound", "session not found")
+        # Call to_dict() on each message to simulate real backend behavior
+        # This catches bugs like empty content (TextMessage.to_dict validates)
+        for msg in messages:
+            msg.to_dict()
+        if session_id not in self.sessions:
+            self.sessions[session_id] = []
+        self.sessions[session_id].extend(messages)
+        self.add_messages_calls.append({
+            "space_id": space_id,
+            "session_id": session_id,
+            "messages": messages,
+        })
+        return MagicMock(items=messages)
+
+    def create_memory_session(self, space_id, id=None, actor_id=None,
+                              assistant_id=None):
+        self.create_memory_session_calls.append({
+            "space_id": space_id,
+            "id": id,
+        })
+
+    def get_last_k_messages(self, session_id, k, space_id):
+        msgs = self.sessions.get(session_id, [])
+        return msgs[-k:] if len(msgs) > k else msgs
+
+    def list_messages(self, space_id, session_id, limit, offset):
+        msgs = self.sessions.get(session_id, [])
+        items = msgs[offset:offset + limit]
+        result = MagicMock()
+        result.items = items
+        return result
+
+    def delete_session(self, space_id, session_id):
+        self.delete_session_attempts += 1
+        if self._delete_session_fail:
+            raise APIException(500, "InternalError", "delete failed")
+        self.sessions.pop(session_id, None)
+        self.delete_session_calls.append({
+            "space_id": space_id,
+            "session_id": session_id,
+        })
+
+    def close(self):
+        self.close_called = True
+
+
+class FakeAsyncMemoryClient:
+    """In-memory mock of AsyncMemoryClient for testing."""
+
+    def __init__(self):
+        self.sessions = {}
+        self.add_messages_calls = []
+        self.delete_session_calls = []
+        self.create_memory_session_calls = []
+        self.close_called = False
+        self._add_messages_fail_404 = False
+        self._delete_session_fail = False
+        self.delete_session_attempts = 0
+
+    async def add_messages(self, space_id, session_id, messages):
+        # Simulate 404 on first call if flag is set
+        if self._add_messages_fail_404:
+            self._add_messages_fail_404 = False
+            raise APIException(404, "NotFound", "session not found")
+        # Call to_dict() on each message to simulate real backend behavior
+        for msg in messages:
+            msg.to_dict()
+        if session_id not in self.sessions:
+            self.sessions[session_id] = []
+        self.sessions[session_id].extend(messages)
+        self.add_messages_calls.append({
+            "space_id": space_id,
+            "session_id": session_id,
+            "messages": messages,
+        })
+        return MagicMock(items=messages)
+
+    async def create_memory_session(self, space_id, id=None, actor_id=None,
+                                    assistant_id=None):
+        self.create_memory_session_calls.append({
+            "space_id": space_id,
+            "id": id,
+        })
+
+    async def get_last_k_messages(self, session_id, k, space_id):
+        msgs = self.sessions.get(session_id, [])
+        return msgs[-k:] if len(msgs) > k else msgs
+
+    async def list_messages(self, space_id, session_id, limit, offset):
+        msgs = self.sessions.get(session_id, [])
+        items = msgs[offset:offset + limit]
+        result = MagicMock()
+        result.items = items
+        return result
+
+    async def delete_session(self, space_id, session_id):
+        self.delete_session_attempts += 1
+        if self._delete_session_fail:
+            raise APIException(500, "InternalError", "delete failed")
+        self.sessions.pop(session_id, None)
+        self.delete_session_calls.append({
+            "space_id": space_id,
+            "session_id": session_id,
+        })
+
+    async def close(self):
+        self.close_called = True
+
+
+def create_saver():
+    """Create a saver with fake clients."""
+    saver = AgentArtsMemorySessionSaver(
+        space_id="test-space",
+        region="cn-southwest-1",
+        api_key="test-api-key",
+    )
+    fake_sync = FakeMemoryClient()
+    fake_async = FakeAsyncMemoryClient()
+    saver._client = fake_sync
+    saver._async_client = fake_async
+    return saver, fake_sync, fake_async
+
+
+def make_config(thread_id, checkpoint_id=None):
+    """Create a RunnableConfig."""
+    config = {"configurable": {"thread_id": thread_id}}
+    if checkpoint_id:
+        config["configurable"]["checkpoint_id"] = checkpoint_id
+    return config
+
+
+def serialize_write(saver, value):
+    """Serialize a value the same way put_writes does."""
+    value_type, value_bytes = saver.serde.dumps_typed(value)
+    return {
+        "value_type": value_type,
+        "value_data": base64.b64encode(value_bytes).decode("ascii"),
+    }
+
+
+def _seed_main_session(fake, thread_id, checkpoint_id, content="Hello"):
+    """Seed the main session with one checkpoint message."""
+    fake.sessions[thread_id] = [FakeMessage(
+        role="user",
+        content=content,
+        meta=json.dumps({
+            "step": 0,
+            "source": "loop",
+            "checkpoint_id": checkpoint_id,
+            "checkpoint_ts": "2024-01-01T00:00:00Z",
+        }),
+    )]
+
+
+class TestPutWrites:
+    """put_writes behavior."""
+
+    def test_put_writes_stores_in_writes_session(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-1"
+        checkpoint_id = "cp-123"
+        config = make_config(thread_id, checkpoint_id)
+
+        writes = [("channel1", "value1"), ("channel2", {"key": "val"})]
+        task_id = "task-001"
+        saver.put_writes(config, writes, task_id)
+
+        assert len(fake_sync.add_messages_calls) == 1
+        call = fake_sync.add_messages_calls[0]
+        expected_writes_session = AgentArtsMemorySessionSaver._writes_session_id(thread_id)
+        assert call["session_id"] == expected_writes_session
+
+        assert len(call["messages"]) == 1
+        msg = call["messages"][0]
+        assert msg.role == "system"
+        assert msg.content == "pending_writes"
+
+        meta = json.loads(msg.meta)
+        assert meta["type"] == "pending_writes"
+        assert meta["checkpoint_id"] == checkpoint_id
+        assert len(meta["writes"]) == 2
+        assert meta["writes"][0]["task_id"] == task_id
+        assert meta["writes"][0]["channel"] == "channel1"
+        assert "value_type" in meta["writes"][0]
+        assert "value_data" in meta["writes"][0]
+
+    def test_put_writes_empty_is_noop(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-5"
+        config = make_config(thread_id, "cp-000")
+
+        saver.put_writes(config, [], "task-005")
+
+        assert len(fake_sync.add_messages_calls) == 0
+
+    def test_put_writes_dedup_first_occurrence_wins(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-6"
+        checkpoint_id = "cp-dedup"
+        _seed_main_session(fake_sync, thread_id, checkpoint_id)
+
+        config = make_config(thread_id, checkpoint_id)
+        saver.put_writes(config, [("output", "first")], "task-A")
+        saver.put_writes(config, [("output", "second")], "task-A")
+
+        result = saver.get_tuple(config)
+        assert result.pending_writes is not None
+        assert len(result.pending_writes) == 1
+        assert result.pending_writes[0][2] == "first"
+
+    def test_put_writes_404_auto_creates_and_retries(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-404"
+        checkpoint_id = "cp-404"
+        config = make_config(thread_id, checkpoint_id)
+
+        fake_sync._add_messages_fail_404 = True
+        saver.put_writes(config, [("channel404", "value404")], "task-404")
+
+        assert len(fake_sync.create_memory_session_calls) == 1
+        create_call = fake_sync.create_memory_session_calls[0]
+        expected_writes_session = saver._writes_session_id(thread_id)
+        assert create_call["id"] == expected_writes_session
+
+        assert len(fake_sync.add_messages_calls) == 1
+        assert expected_writes_session in fake_sync.sessions
+        assert len(fake_sync.sessions[expected_writes_session]) == 1
+
+
+class TestAPutWrites:
+    """aput_writes behavior (async)."""
+
+    @pytest.mark.asyncio
+    async def test_aput_writes_stores_in_writes_session(self):
+        saver, _, fake_async = create_saver()
+        thread_id = "test-thread-7"
+        checkpoint_id = "cp-async-1"
+        config = make_config(thread_id, checkpoint_id)
+
+        await saver.aput_writes(config, [("channelA", "valueA")], "task-007")
+
+        assert len(fake_async.add_messages_calls) == 1
+        call = fake_async.add_messages_calls[0]
+        assert call["session_id"] == saver._writes_session_id(thread_id)
+        meta = json.loads(call["messages"][0].meta)
+        assert meta["type"] == "pending_writes"
+        assert len(meta["writes"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_aput_writes_404_auto_creates_and_retries(self):
+        saver, _, fake_async = create_saver()
+        thread_id = "test-thread-404-async"
+        checkpoint_id = "cp-404-async"
+        config = make_config(thread_id, checkpoint_id)
+
+        fake_async._add_messages_fail_404 = True
+        await saver.aput_writes(config, [("channelA404", "valueA404")], "task-404-async")
+
+        assert len(fake_async.create_memory_session_calls) == 1
+        create_call = fake_async.create_memory_session_calls[0]
+        expected_writes_session = saver._writes_session_id(thread_id)
+        assert create_call["id"] == expected_writes_session
+
+        assert len(fake_async.add_messages_calls) == 1
+        assert expected_writes_session in fake_async.sessions
+        assert len(fake_async.sessions[expected_writes_session]) == 1
+
+
+class TestGetTuplePendingWrites:
+    """get_tuple pending_writes roundtrip."""
+
+    def test_roundtrip(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-2"
+        checkpoint_id = "cp-456"
+        _seed_main_session(fake_sync, thread_id, checkpoint_id)
+
+        config = make_config(thread_id, checkpoint_id)
+        saver.put_writes(config, [("output", "result-value")], "task-002")
+
+        result = saver.get_tuple(config)
+        assert result is not None
+        assert result.pending_writes is not None
+        assert len(result.pending_writes) == 1
+        pw = result.pending_writes[0]
+        assert pw[0] == "task-002"
+        assert pw[1] == "output"
+        assert pw[2] == "result-value"
+
+    @pytest.mark.asyncio
+    async def test_async_roundtrip(self):
+        saver, _, fake_async = create_saver()
+        thread_id = "test-thread-8"
+        checkpoint_id = "cp-async-2"
+        _seed_main_session(fake_async, thread_id, checkpoint_id, content="Async test")
+
+        config = make_config(thread_id, checkpoint_id)
+        await saver.aput_writes(config, [("result", {"data": "async-value"})], "task-008")
+
+        result = await saver.aget_tuple(config)
+        assert result is not None
+        assert result.pending_writes is not None
+        assert len(result.pending_writes) == 1
+        pw = result.pending_writes[0]
+        assert pw[0] == "task-008"
+        assert pw[1] == "result"
+        assert pw[2] == {"data": "async-value"}
+
+
+class TestListPendingWrites:
+    """list / alist pending_writes extraction."""
+
+    def _seed_writes_session(self, saver, fake, thread_id, checkpoint_id,
+                             task_id, channel, value):
+        writes_data = [{
+            "task_id": task_id,
+            "task_path": "",
+            "channel": channel,
+            "write_idx": 0,
+            **serialize_write(saver, value),
+        }]
+        fake.sessions[saver._writes_session_id(thread_id)] = [FakeMessage(
+            role="system",
+            content="",
+            meta=json.dumps({
+                "type": "pending_writes",
+                "checkpoint_id": checkpoint_id,
+                "writes": writes_data,
+            }),
+        )]
+
+    def test_list_retrieves_pending_writes(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-3"
+        checkpoint_id = "cp-789"
+        _seed_main_session(fake_sync, thread_id, checkpoint_id, content="Test")
+        self._seed_writes_session(
+            saver, fake_sync, thread_id, checkpoint_id, "task-003", "data", "test-data"
+        )
+
+        result = saver.list(make_config(thread_id))
+        assert len(result) == 1
+        checkpoint_tuple = result[0]
+        assert checkpoint_tuple.pending_writes is not None
+        assert len(checkpoint_tuple.pending_writes) == 1
+        pw = checkpoint_tuple.pending_writes[0]
+        assert pw[0] == "task-003"
+        assert pw[1] == "data"
+        assert pw[2] == "test-data"
+
+    @pytest.mark.asyncio
+    async def test_alist_retrieves_pending_writes(self):
+        saver, _, fake_async = create_saver()
+        thread_id = "test-thread-9"
+        checkpoint_id = "cp-async-3"
+        _seed_main_session(fake_async, thread_id, checkpoint_id, content="Async list test")
+        self._seed_writes_session(
+            saver, fake_async, thread_id, checkpoint_id, "task-009", "async-channel", "async-data"
+        )
+
+        result = await saver.alist(make_config(thread_id))
+        assert len(result) == 1
+        checkpoint_tuple = result[0]
+        assert checkpoint_tuple.pending_writes is not None
+        assert len(checkpoint_tuple.pending_writes) == 1
+        pw = checkpoint_tuple.pending_writes[0]
+        assert pw[0] == "task-009"
+        assert pw[1] == "async-channel"
+        assert pw[2] == "async-data"
+
+
+class TestDeleteThread:
+    """delete_thread / adelete_thread behavior."""
+
+    def test_delete_thread_deletes_both_sessions(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-4"
+
+        fake_sync.sessions[thread_id] = [FakeMessage(role="user", content="main")]
+        fake_sync.sessions[saver._writes_session_id(thread_id)] = [FakeMessage(role="system", content="writes")]
+        saver._persisted_count[thread_id] = 5
+
+        saver.delete_thread(thread_id)
+
+        assert len(fake_sync.delete_session_calls) == 2
+        deleted_sessions = [call["session_id"] for call in fake_sync.delete_session_calls]
+        assert thread_id in deleted_sessions
+        assert saver._writes_session_id(thread_id) in deleted_sessions
+        assert thread_id not in saver._persisted_count
+        assert thread_id not in fake_sync.sessions
+        assert saver._writes_session_id(thread_id) not in fake_sync.sessions
+
+    def test_delete_thread_writes_session_deleted_first(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-order"
+
+        saver.delete_thread(thread_id)
+
+        assert len(fake_sync.delete_session_calls) == 2
+        deleted_sessions = [call["session_id"] for call in fake_sync.delete_session_calls]
+        writes_sid = saver._writes_session_id(thread_id)
+        assert deleted_sessions[0] == writes_sid
+        assert deleted_sessions[1] == thread_id
+
+    def test_delete_thread_swallows_failures_and_cleans_up(self):
+        saver, fake_sync, _ = create_saver()
+        thread_id = "test-thread-swallow"
+        saver._persisted_count[thread_id] = 5
+        fake_sync._delete_session_fail = True
+
+        saver.delete_thread(thread_id)  # must NOT raise
+
+        assert fake_sync.delete_session_attempts == 2
+        assert thread_id not in saver._persisted_count
+
+    @pytest.mark.asyncio
+    async def test_adelete_thread_deletes_both_sessions(self):
+        saver, _, fake_async = create_saver()
+        thread_id = "test-thread-10"
+
+        fake_async.sessions[thread_id] = [FakeMessage(role="user", content="main")]
+        fake_async.sessions[saver._writes_session_id(thread_id)] = [FakeMessage(role="system", content="writes")]
+        saver._persisted_count[thread_id] = 10
+
+        await saver.adelete_thread(thread_id)
+
+        assert len(fake_async.delete_session_calls) == 2
+        deleted_sessions = [call["session_id"] for call in fake_async.delete_session_calls]
+        assert thread_id in deleted_sessions
+        assert saver._writes_session_id(thread_id) in deleted_sessions
+        assert thread_id not in saver._persisted_count
+
+    @pytest.mark.asyncio
+    async def test_adelete_thread_order_and_swallow(self):
+        saver, _, fake_async = create_saver()
+        thread_id = "test-thread-async-order"
+
+        # Normal path: verify order
+        await saver.adelete_thread(thread_id)
+        deleted_sessions = [call["session_id"] for call in fake_async.delete_session_calls]
+        writes_sid = saver._writes_session_id(thread_id)
+        assert len(deleted_sessions) == 2
+        assert deleted_sessions[0] == writes_sid
+        assert deleted_sessions[1] == thread_id
+        assert thread_id not in saver._persisted_count
+
+        # Failure path: no raise + cleanup
+        saver._persisted_count[thread_id] = 7
+        fake_async._delete_session_fail = True
+        await saver.adelete_thread(thread_id)  # must not raise
+        assert fake_async.delete_session_attempts == 4
+        assert thread_id not in saver._persisted_count
+
+
+class TestContextManager:
+    """Sync / async context manager close behavior."""
+
+    def test_sync_context_manager_closes_sync_client_only(self):
+        saver, fake_sync, fake_async = create_saver()
+
+        with saver as s:
+            assert s is saver
+
+        assert fake_sync.close_called
+        assert not fake_async.close_called
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes_both(self):
+        saver, fake_sync, fake_async = create_saver()
+
+        async with saver as s:
+            assert s is saver
+
+        assert fake_sync.close_called
+        assert fake_async.close_called

--- a/tests/unit/sdk/service/test_memory_service_exceptions.py
+++ b/tests/unit/sdk/service/test_memory_service_exceptions.py
@@ -1,0 +1,332 @@
+"""Unit tests for MemoryHttpService / AsyncMemoryHttpService exception semantics.
+
+Covers the service-layer exception fixes (service-exception-fix-plan.md Part A):
+- Network errors (timeout / connection refused) -> MemoryAPIException(status_code=0, NETWORK_ERROR)
+  with original exception chained via __cause__
+- Real HTTP errors (503 / 404) keep their actual status_code
+- 2xx success unchanged
+- 2xx with invalid JSON body -> MemoryAPIException(status_code=<actual>, PARSE_ERROR)
+- is_network_error / retryable properties
+"""
+
+import httpx
+import pytest
+from requests.exceptions import ConnectionError, Timeout
+
+from agentarts.sdk.service.http_client import (
+    APIException,
+    MemoryAPIException,
+)
+from agentarts.sdk.service.memory_service import MemoryHttpService
+from agentarts.sdk.service.memory_service_async import AsyncMemoryHttpService
+
+
+def _sync_service() -> MemoryHttpService:
+    """Create a data-plane MemoryHttpService (no AK/SK signing needed)."""
+    return MemoryHttpService(
+        region_name="cn-north-4",
+        endpoint_type="data",
+        api_key="test-api-key",
+        verify_ssl=False,
+    )
+
+
+def _async_service() -> AsyncMemoryHttpService:
+    """Create a data-plane AsyncMemoryHttpService."""
+    return AsyncMemoryHttpService(
+        region_name="cn-north-4",
+        endpoint_type="data",
+        api_key="test-api-key",
+        verify_ssl=False,
+    )
+
+
+def _sync_resp(mocker, status_code, json_data=None, text="", raise_json=False):
+    """Create a sync requests-like response mock.
+
+    Note: real requests.Response.headers is case-insensitive, so the mock must
+    expose the lowercase key the production code looks up ("content-type").
+    """
+    mock_resp = mocker.MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.ok = 200 <= status_code < 300
+    mock_resp.headers = {"content-type": "application/json"}
+    if raise_json:
+        mock_resp.json.side_effect = ValueError("Invalid JSON")
+    else:
+        mock_resp.json.return_value = json_data
+    mock_resp.text = text
+    mock_resp.content = text.encode()
+    return mock_resp
+
+
+class _FakeAsyncClient:
+    """Fake httpx.AsyncClient: request() delegates to a handler.
+
+    httpx.Response.headers is also case-insensitive, so handlers build
+    responses with lowercase "content-type" key.
+    """
+
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def request(self, *args, **kwargs):
+        return await self._handler(*args, **kwargs)
+
+
+class _FakeAsyncResp:
+    """Fake httpx.Response with a case-insensitive-style headers dict."""
+
+    def __init__(self, status_code, json_data=None, text="", raise_json=False):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.headers = {"content-type": "application/json"}
+        self._json_data = json_data
+        self._text = text
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("Invalid JSON")
+        return self._json_data
+
+    @property
+    def text(self):
+        return self._text
+
+
+def _patch_async_client(mocker, service, handler):
+    """Patch _get_client to return a fake client whose request() is the handler."""
+    mocker.patch.object(
+        service, "_get_client", return_value=_FakeAsyncClient(handler)
+    )
+
+
+class TestSyncExceptionSemantics:
+    """Sync MemoryHttpService exception wrapping semantics."""
+
+    def test_network_timeout(self, mocker):
+        """Timeout -> MemoryAPIException(status_code=0, NETWORK_ERROR), __cause__ preserved."""
+        service = _sync_service()
+        mocker.patch.object(
+            service.session, "request", side_effect=Timeout("read timeout")
+        )
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 0
+        assert exc.error_code == "NETWORK_ERROR"
+        assert exc.is_network_error is True
+        assert exc.retryable is True
+        assert isinstance(exc.__cause__, Timeout)
+
+    def test_connection_error(self, mocker):
+        """ConnectionError -> MemoryAPIException(status_code=0, NETWORK_ERROR)."""
+        service = _sync_service()
+        mocker.patch.object(
+            service.session, "request", side_effect=ConnectionError("conn refused")
+        )
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 0
+        assert exc.error_code == "NETWORK_ERROR"
+        assert exc.is_network_error is True
+        assert exc.retryable is True
+        assert isinstance(exc.__cause__, ConnectionError)
+
+    def test_real_503_keeps_status_code(self, mocker):
+        """Real 503 -> status_code=503, error_code from backend body, NOT network error."""
+        service = _sync_service()
+        mock_resp = _sync_resp(
+            mocker,
+            503,
+            json_data={"error_code": "INTERNAL_ERROR", "error_msg": "server busy"},
+            text="server busy",
+        )
+        mocker.patch.object(service.session, "request", return_value=mock_resp)
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 503
+        assert exc.error_code == "INTERNAL_ERROR"
+        assert exc.is_network_error is False
+        assert exc.retryable is True  # 503 is retryable
+
+    def test_real_404_keeps_status_code(self, mocker):
+        """Real 404 -> status_code=404, not misclassified."""
+        service = _sync_service()
+        mock_resp = _sync_resp(
+            mocker,
+            404,
+            json_data={"error_code": "NOT_FOUND", "error_msg": "Session not found"},
+            text="Session not found",
+        )
+        mocker.patch.object(service.session, "request", return_value=mock_resp)
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 404
+        assert exc.error_code == "NOT_FOUND"
+        assert exc.is_network_error is False
+        assert exc.retryable is False  # 404 not retryable
+
+    def test_2xx_success_unchanged(self, mocker):
+        """2xx JSON response still returns parsed dict."""
+        service = _sync_service()
+        mock_resp = _sync_resp(mocker, 200, json_data={"ok": True}, text='{"ok": true}')
+        mocker.patch.object(service.session, "request", return_value=mock_resp)
+
+        result = service._make_request("GET", "/v1/core/spaces", space_id="s1")
+        assert result == {"ok": True}
+
+    def test_2xx_invalid_json_parse_error(self, mocker):
+        """2xx + Content-Type json + invalid body -> PARSE_ERROR with actual status_code."""
+        service = _sync_service()
+        mock_resp = _sync_resp(
+            mocker, 200, text="<html>gateway error</html>", raise_json=True
+        )
+        mocker.patch.object(service.session, "request", return_value=mock_resp)
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 200
+        assert exc.error_code == "PARSE_ERROR"
+        assert exc.is_network_error is False
+        assert exc.retryable is False  # parse error: no point retrying
+
+    def test_204_no_content(self, mocker):
+        """204 -> empty dict, no exception."""
+        service = _sync_service()
+        mock_resp = _sync_resp(mocker, 204)
+        mocker.patch.object(service.session, "request", return_value=mock_resp)
+
+        result = service._make_request("DELETE", "/v1/core/spaces/x", space_id="s1")
+        assert result == {}
+
+
+class TestAsyncExceptionSemantics:
+    """Async AsyncMemoryHttpService exception wrapping semantics."""
+
+    @pytest.mark.asyncio
+    async def test_async_network_timeout(self, mocker):
+        """Async timeout -> MemoryAPIException(status_code=0, NETWORK_ERROR)."""
+        service = _async_service()
+
+        async def _handler(*args, **kwargs):
+            raise httpx.TimeoutException("async read timeout")
+
+        _patch_async_client(mocker, service, _handler)
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            await service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 0
+        assert exc.error_code == "NETWORK_ERROR"
+        assert exc.is_network_error is True
+        assert exc.retryable is True
+        assert isinstance(exc.__cause__, httpx.TimeoutException)
+
+    @pytest.mark.asyncio
+    async def test_async_real_503(self, mocker):
+        """Async real 503 keeps status_code, not network error."""
+        service = _async_service()
+
+        async def _handler(*args, **kwargs):
+            return _FakeAsyncResp(
+                503,
+                json_data={"error_code": "INTERNAL_ERROR", "error_msg": "server busy"},
+                text="server busy",
+            )
+
+        _patch_async_client(mocker, service, _handler)
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            await service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 503
+        assert exc.error_code == "INTERNAL_ERROR"
+        assert exc.is_network_error is False
+        assert exc.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_async_2xx_invalid_json_parse_error(self, mocker):
+        """Async 2xx + invalid JSON -> PARSE_ERROR."""
+        service = _async_service()
+
+        async def _handler(*args, **kwargs):
+            return _FakeAsyncResp(200, text="<html>bad</html>", raise_json=True)
+
+        _patch_async_client(mocker, service, _handler)
+
+        with pytest.raises(MemoryAPIException) as exc_info:
+            await service._make_request("GET", "/v1/core/spaces", space_id="s1")
+
+        exc = exc_info.value
+        assert exc.status_code == 200
+        assert exc.error_code == "PARSE_ERROR"
+        assert exc.is_network_error is False
+
+    @pytest.mark.asyncio
+    async def test_async_2xx_success(self, mocker):
+        """Async 2xx success unchanged."""
+        service = _async_service()
+
+        async def _handler(*args, **kwargs):
+            return _FakeAsyncResp(200, json_data={"ok": True}, text='{"ok": true}')
+
+        _patch_async_client(mocker, service, _handler)
+
+        result = await service._make_request("GET", "/v1/core/spaces", space_id="s1")
+        assert result == {"ok": True}
+
+
+class TestMemoryAPIExceptionProperties:
+    """MemoryAPIException property semantics."""
+
+    def test_network_error_property(self):
+        exc = MemoryAPIException(status_code=0, error_code="NETWORK_ERROR", error_msg="timeout")
+        assert exc.is_network_error is True
+        assert exc.retryable is True
+
+    def test_429_retryable(self):
+        exc = MemoryAPIException(
+            status_code=429, error_code="RATE_LIMITED", error_msg="rate limited"
+        )
+        assert exc.is_network_error is False
+        assert exc.retryable is True
+
+    def test_500_retryable(self):
+        exc = MemoryAPIException(status_code=500, error_code="INTERNAL_ERROR", error_msg="internal")
+        assert exc.retryable is True
+
+    def test_400_not_retryable(self):
+        exc = MemoryAPIException(
+            status_code=400, error_code="BAD_REQUEST", error_msg="bad request"
+        )
+        assert exc.is_network_error is False
+        assert exc.retryable is False
+
+    def test_is_subclass_of_api_exception(self):
+        """MemoryAPIException must remain a subclass of APIException (backward compat)."""
+        exc = MemoryAPIException(status_code=0, error_code="NETWORK_ERROR", error_msg="x")
+        assert isinstance(exc, APIException)
+
+    def test_str_contains_details(self):
+        exc = MemoryAPIException(
+            status_code=404, error_code="NOT_FOUND", error_msg="Session not found"
+        )
+        assert "404" in str(exc)
+        assert "Session not found" in str(exc)


### PR DESCRIPTION
## Description

### Summary

This PR fixes two related issues in the SDK.

First, network errors in the memory HTTP clients were previously wrapped as `MemoryAPIException` with `status_code=503`, which falsely implies the server returned a "Service Unavailable" response. In reality these failures (timeouts, connection refused, DNS errors) never produced an HTTP response at all. They are now reported with `status_code=0` to signal "no HTTP response", and the original exception is preserved through the standard exception chain so callers can inspect the root cause via `__cause__`. As a related cleanup, 2xx responses with a non-JSON body are no longer mislabeled as network errors; they now raise `MemoryAPIException` with a dedicated `PARSE_ERROR` error code while keeping the actual HTTP status code.

Second, `MemoryAPIException` was defined twice, once in each of the sync and async memory service modules, which made the two classes distinct despite sharing a name. It is now defined once in the shared HTTP client module and exported from the public service package, together with two new helper properties (`is_network_error` and `retryable`) that let callers classify errors without string matching on error codes.

Third, `delete_thread` and `adelete_thread` in the LangGraph checkpoint saver were restructured so that the writes session is deleted before the main session, and the in-memory persisted-count cleanup always runs via a `finally` block even when session deletion fails. The existing swallow-exception contract is preserved: deletion failures are logged but not propagated, and idempotent behavior is unchanged.

### Behavior changes

- Network errors: `status_code` changes from `503` to `0` (no server response).
- New `PARSE_ERROR` error code for 2xx responses with invalid JSON bodies.
- `MemoryAPIException` is now importable from the public service package (`is_network_error` / `retryable` properties added).
- `delete_thread` / `adelete_thread`: writes session deleted first; persisted-count cleanup guaranteed via `try/finally`; swallow-exception contract unchanged.

Backward compatibility is maintained: `MemoryAPIException` remains a subclass of `APIException`, so existing `except APIException` handlers continue to work, and the package export is purely additive.

## Verification

Verified with unit tests covering both synchronous and asynchronous client paths. The tests exercise the full error classification flow: timeouts and connection errors surface as network errors with no HTTP status and preserve the original exception for inspection; real HTTP 503 and 404 responses keep their actual status codes and are correctly distinguished from network-level failures; 2xx responses with non-JSON bodies are classified as parse errors rather than network errors; and successful 2xx responses pass through unchanged. The new classification properties were also asserted across network, rate-limit, server-error, and client-error cases to confirm retry semantics. For the checkpoint saver, tests verify that deleting a thread removes the writes session before the main session, that the persisted-count tracking is always cleaned up even when deletion fails, and that both sync and async paths behave identically without propagating deletion errors. A simulated end-to-end data flow exercise covering these same scenarios was run successfully to confirm the changes work together in practice.
